### PR TITLE
feat: scaffold local spaced repetition dashboard

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+out
+.DS_Store
+.env*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-# Spaced-Repetition-App
+# Spaced Repetition App
+
+A local-first spaced repetition dashboard built with Next.js, Tailwind CSS, and Zustand. Capture learning topics, assign categories, customize review intervals, and keep track of what needs attention each day.
+
+## Features
+
+- Topic composer with notes, icon, color, category, reminder time, and flexible intervals
+- Dashboard showing all items due for review today
+- Local persistence using Zustand + `localStorage`
+- Tailwind-based UI using shadcn-inspired primitives and Lucide icons
+
+## Getting started
+
+Install dependencies and run the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Then open http://localhost:3000 in your browser.
+
+## Tech stack
+
+- Next.js 14 (App Router)
+- React 18 with TypeScript
+- Tailwind CSS with custom tokens
+- Zustand for client-side state + persistence
+- Radix UI primitives, Lucide icons, and Framer Motion for animation
+
+## Project structure
+
+```
+src/
+  app/(pages)/page.tsx      # Root page
+  app/layout.tsx            # Global layout + fonts
+  components/               # UI, forms, dashboard widgets
+  stores/topics.ts          # Zustand state + persistence
+  lib/                      # Utility helpers and constants
+  types/                    # Shared TypeScript types
+```
+
+## Data persistence
+
+All topics and categories are stored in the browser via `localStorage`. This keeps the app completely local and private. Clearing browser storage will remove saved topics.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true,
+    serverActions: false
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "spaced-repetition-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@radix-ui/react-popover": "^1.0.7",
+    "@radix-ui/react-scroll-area": "^1.0.6",
+    "@radix-ui/react-select": "^2.0.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "framer-motion": "^11.1.7",
+    "lucide-react": "^0.378.0",
+    "next": "^14.2.3",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "sonner": "^1.4.2",
+    "zustand": "^4.5.2",
+    "uuid": "^9.0.1",
+    "tailwind-merge": "^2.3.0",
+    "@radix-ui/react-slot": "^1.0.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.2.79",
+    "@types/react-dom": "^18.2.25",
+    "autoprefixer": "^10.4.18",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5",
+    "tailwindcss-animate": "^1.0.7"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app/(pages)/page.tsx
+++ b/src/app/(pages)/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import * as React from "react";
+import { TopicForm } from "@/components/forms/topic-form";
+import { Dashboard } from "@/components/dashboard/dashboard";
+import { Button } from "@/components/ui/button";
+import { motion } from "framer-motion";
+import { CalendarClock } from "lucide-react";
+import { useReminderScheduler } from "@/hooks/use-reminder-scheduler";
+
+export default function HomePage() {
+  const [showForm, setShowForm] = React.useState(true);
+  useReminderScheduler();
+
+  return (
+    <main className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-8 px-4 py-10 md:px-6 lg:px-8">
+      <motion.section
+        layout
+        className="flex flex-col gap-6 rounded-3xl border border-white/5 bg-gradient-to-br from-white/10 via-white/5 to-white/0 p-8 shadow-2xl"
+      >
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-start gap-4">
+            <div className="rounded-2xl bg-accent/20 p-3 text-accent">
+              <CalendarClock className="h-6 w-6" />
+            </div>
+            <div>
+              <h1 className="text-3xl font-semibold text-white">Spaced Repetition, simplified</h1>
+              <p className="max-w-2xl text-sm text-zinc-300">
+                Capture topics, craft your review cadence, and keep knowledge fresh with local-first
+                storage. Everything stays on your device while reminders and intervals keep you on
+                track.
+              </p>
+            </div>
+          </div>
+          <Button variant="outline" onClick={() => setShowForm((previous) => !previous)}>
+            {showForm ? "Hide form" : "Add new topic"}
+          </Button>
+        </div>
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,360px)_1fr]">
+          {showForm ? <TopicForm /> : null}
+          <Dashboard onCreateTopic={() => setShowForm(true)} />
+        </div>
+      </motion.section>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-surface text-surface-foreground font-sans antialiased;
+}
+
+* {
+  @apply border-border;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+import { Toaster } from "sonner";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+
+export const metadata: Metadata = {
+  title: "Spaced Repetition",
+  description: "Local spaced repetition dashboard"
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${inter.variable} min-h-screen bg-surface text-surface-foreground`}>        
+        <Toaster richColors position="top-right" />
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import * as React from "react";
+import { useTopicStore } from "@/stores/topics";
+import { TopicCard } from "@/components/dashboard/topic-card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Button } from "@/components/ui/button";
+import { motion } from "framer-motion";
+import { Plus } from "lucide-react";
+import { IconPreview } from "@/components/icon-preview";
+
+interface DashboardProps {
+  onCreateTopic: () => void;
+}
+
+export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic }) => {
+  const topics = useTopicStore((state) => state.topics);
+  const dueTopics = React.useMemo(
+    () => topics.filter((topic) => new Date(topic.nextReviewDate) <= new Date()),
+    [topics]
+  );
+
+  return (
+    <section className="flex h-full flex-col gap-6">
+      <header className="flex flex-col gap-3">
+        <motion.h1
+          layoutId="title"
+          className="text-2xl font-semibold text-white"
+        >
+          Today&apos;s Reviews
+        </motion.h1>
+        <p className="text-sm text-zinc-400">
+          Keep your streak alive by reviewing topics scheduled for today. Marking a card as reviewed
+          will automatically plan the next session based on your interval strategy.
+        </p>
+        <div className="flex flex-wrap items-center gap-3 text-xs text-zinc-400">
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1">
+            <span className="h-2 w-2 rounded-full bg-accent" />
+            Due today
+          </span>
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/5 px-3 py-1">
+            <span className="h-2 w-2 rounded-full bg-muted" />
+            Scheduled
+          </span>
+        </div>
+      </header>
+
+      {topics.length === 0 ? (
+        <div className="flex flex-1 items-center justify-center rounded-3xl border border-dashed border-white/10 bg-white/5 p-10 text-center">
+          <div className="max-w-sm space-y-4">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-accent/20 text-accent">
+              <IconPreview name="Sparkles" className="h-8 w-8" />
+            </div>
+            <h2 className="text-xl font-semibold text-white">Create your first topic</h2>
+            <p className="text-sm text-zinc-400">
+              Add notes, icons, intervals, and reminders to stay on top of the subjects that matter
+              most to you.
+            </p>
+            <Button onClick={onCreateTopic} className="gap-2">
+              <Plus className="h-4 w-4" />
+              New topic
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <ScrollArea className="flex-1">
+          <div className="grid grid-cols-1 gap-4 pb-4 md:grid-cols-2 xl:grid-cols-3">
+            {dueTopics.length > 0 ? (
+              dueTopics.map((topic) => <TopicCard key={topic.id} {...topic} />)
+            ) : (
+              <div className="col-span-full rounded-3xl border border-white/5 bg-white/5 p-6 text-center text-sm text-zinc-400">
+                Nothing due right now. Kick things off by scheduling a new topic or review
+                upcoming cards ahead of time.
+              </div>
+            )}
+          </div>
+        </ScrollArea>
+      )}
+    </section>
+  );
+};

--- a/src/components/dashboard/topic-card.tsx
+++ b/src/components/dashboard/topic-card.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import * as React from "react";
+import { motion } from "framer-motion";
+import { IconPreview } from "@/components/icon-preview";
+import { Button } from "@/components/ui/button";
+import { useTopicStore } from "@/stores/topics";
+import { formatDate, formatTime, isDueToday } from "@/lib/date";
+import { cn } from "@/lib/utils";
+
+interface TopicCardProps {
+  id: string;
+  title: string;
+  notes: string;
+  categoryLabel: string;
+  color: string;
+  icon: string;
+  nextReviewDate: string;
+  reminderTime: string | null;
+  intervals: number[];
+  currentIntervalIndex: number;
+}
+
+export const TopicCard: React.FC<TopicCardProps> = ({
+  id,
+  title,
+  notes,
+  categoryLabel,
+  color,
+  icon,
+  nextReviewDate,
+  reminderTime,
+  intervals,
+  currentIntervalIndex
+}) => {
+  const markReviewed = useTopicStore((state) => state.markReviewed);
+  const deleteTopic = useTopicStore((state) => state.deleteTopic);
+  const due = isDueToday(nextReviewDate);
+  const totalIntervals = Math.max(intervals.length, 1);
+  const progress = Math.round(((Math.min(currentIntervalIndex, totalIntervals - 1) + 1) / totalIntervals) * 100);
+
+  return (
+    <motion.article
+      layout
+      transition={{ type: "spring", stiffness: 300, damping: 24 }}
+      className="group flex h-full flex-col justify-between rounded-3xl border border-white/5 bg-white/5 p-5 shadow-lg backdrop-blur"
+    >
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="flex h-10 w-10 items-center justify-center rounded-2xl" style={{ backgroundColor: `${color}22` }}>
+              <IconPreview name={icon} className="h-5 w-5" />
+            </span>
+            <div>
+              <h3 className="text-lg font-semibold text-white">{title}</h3>
+              <p className="text-xs uppercase tracking-wide text-zinc-400">{categoryLabel}</p>
+            </div>
+          </div>
+          <span
+            className={cn(
+              "rounded-full px-3 py-1 text-xs font-medium",
+              due ? "bg-accent text-accent-foreground" : "bg-muted text-zinc-300"
+            )}
+          >
+            {due ? "Due today" : `Due ${formatDate(nextReviewDate)}`}
+          </span>
+        </div>
+        {notes ? (
+          <p className="line-clamp-3 text-sm leading-relaxed text-zinc-200/90">{notes}</p>
+        ) : (
+          <p className="text-sm text-zinc-400">No notes yet</p>
+        )}
+      </div>
+
+      <div className="mt-6 space-y-3">
+        <div className="flex items-center justify-between text-xs text-zinc-400">
+          <span>Reminder</span>
+          <span>{formatTime(reminderTime)}</span>
+        </div>
+        <div className="flex items-center justify-between text-xs text-zinc-400">
+          <span>Interval</span>
+          <span>
+            {intervals[currentIntervalIndex]} day{intervals[currentIntervalIndex] === 1 ? "" : "s"}
+          </span>
+        </div>
+        <div className="h-2 rounded-full bg-zinc-800">
+          <div
+            className="h-full rounded-full bg-accent"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <Button
+            type="button"
+            className="flex-1"
+            onClick={() => markReviewed(id)}
+            disabled={!due}
+          >
+            {due ? "Mark Reviewed" : "Scheduled"}
+          </Button>
+          <Button type="button" variant="ghost" onClick={() => deleteTopic(id)}>
+            Delete
+          </Button>
+        </div>
+      </div>
+    </motion.article>
+  );
+};

--- a/src/components/forms/color-picker.tsx
+++ b/src/components/forms/color-picker.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { COLOR_OPTIONS } from "@/lib/constants";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+interface ColorPickerProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export const ColorPicker: React.FC<ColorPickerProps> = ({ value, onChange }) => {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" className="h-10 w-full justify-start gap-3">
+          <span
+            className="h-6 w-6 rounded-full border border-white/30"
+            style={{ backgroundColor: value }}
+          />
+          <span className="text-sm text-zinc-200">{value.toUpperCase()}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64" sideOffset={12}>
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">Color</p>
+        <div className="grid grid-cols-5 gap-2">
+          {COLOR_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              className={cn(
+                "flex h-10 w-10 items-center justify-center rounded-full border border-transparent transition-transform hover:scale-105",
+                option === value && "ring-2 ring-accent"
+              )}
+              style={{ backgroundColor: option }}
+              onClick={() => onChange(option)}
+            >
+              {option === value ? <span className="h-2 w-2 rounded-full bg-white" /> : null}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/forms/icon-picker.tsx
+++ b/src/components/forms/icon-picker.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { ICON_OPTIONS } from "@/lib/constants";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { IconPreview } from "@/components/icon-preview";
+
+interface IconPickerProps {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export const IconPicker: React.FC<IconPickerProps> = ({ value, onChange }) => {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" className="h-10 w-full justify-start gap-3">
+          <IconPreview name={value} className="h-5 w-5" />
+          <span className="text-sm text-zinc-200">{value}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64" sideOffset={12}>
+        <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">Icon</p>
+        <div className="grid grid-cols-4 gap-2">
+          {ICON_OPTIONS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => onChange(option)}
+              className="flex h-12 w-full items-center justify-center rounded-lg border border-transparent bg-card/80 transition hover:border-accent"
+            >
+              <IconPreview name={option} className="h-5 w-5" />
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/src/components/forms/interval-editor.tsx
+++ b/src/components/forms/interval-editor.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { DEFAULT_INTERVALS } from "@/lib/constants";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface IntervalEditorProps {
+  value: number[];
+  onChange: (intervals: number[]) => void;
+}
+
+export const IntervalEditor: React.FC<IntervalEditorProps> = ({ value, onChange }) => {
+  const [customValue, setCustomValue] = React.useState("");
+
+  const togglePreset = (days: number) => {
+    if (value.includes(days)) {
+      onChange(value.filter((interval) => interval !== days));
+    } else {
+      onChange([...value, days].sort((a, b) => a - b));
+    }
+  };
+
+  const handleAddCustom = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const parsed = Number(customValue);
+    if (!Number.isFinite(parsed) || parsed <= 0) return;
+    if (value.includes(parsed)) return;
+    onChange([...value, parsed].sort((a, b) => a - b));
+    setCustomValue("");
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap gap-2">
+        {DEFAULT_INTERVALS.map((preset) => {
+          const active = value.includes(preset.days);
+          return (
+            <Button
+              key={preset.id}
+              type="button"
+              variant={active ? "default" : "outline"}
+              className="rounded-full px-4"
+              onClick={() => togglePreset(preset.days)}
+            >
+              {preset.label}
+            </Button>
+          );
+        })}
+      </div>
+      <form onSubmit={handleAddCustom} className="flex items-center gap-2">
+        <Input
+          value={customValue}
+          onChange={(event) => setCustomValue(event.target.value)}
+          placeholder="Custom (days)"
+          className="w-32"
+          inputMode="numeric"
+        />
+        <Button type="submit" variant="outline">
+          Add
+        </Button>
+      </form>
+      <p className="text-xs text-zinc-400">
+        Intervals determine when the topic will be reviewed again. The first interval schedules the
+        next session.
+      </p>
+    </div>
+  );
+};

--- a/src/components/forms/topic-form.tsx
+++ b/src/components/forms/topic-form.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import * as React from "react";
+import { useTopicStore } from "@/stores/topics";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import { ColorPicker } from "@/components/forms/color-picker";
+import { IconPicker } from "@/components/forms/icon-picker";
+import { IntervalEditor } from "@/components/forms/interval-editor";
+import { DEFAULT_INTERVALS } from "@/lib/constants";
+import { toast } from "sonner";
+
+const defaultIntervals = DEFAULT_INTERVALS.map((preset) => preset.days);
+
+export const TopicForm: React.FC = () => {
+  const { addTopic, categories, addCategory } = useTopicStore();
+  const [title, setTitle] = React.useState("");
+  const [notes, setNotes] = React.useState("");
+  const [categoryId, setCategoryId] = React.useState<string | null>("general");
+  const [categoryLabel, setCategoryLabel] = React.useState("General");
+  const [newCategory, setNewCategory] = React.useState("");
+  const [icon, setIcon] = React.useState("Sparkles");
+  const [color, setColor] = React.useState("#38bdf8");
+  const [reminderTime, setReminderTime] = React.useState<string | null>(null);
+  const [intervals, setIntervals] = React.useState<number[]>(defaultIntervals);
+
+  const resetForm = () => {
+    setTitle("");
+    setNotes("");
+    setCategoryId("general");
+    setCategoryLabel("General");
+    setIcon("Sparkles");
+    setColor("#38bdf8");
+    setReminderTime(null);
+    setIntervals(defaultIntervals);
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!title.trim()) {
+      toast.error("Topic title is required");
+      return;
+    }
+
+    let resolvedCategoryId = categoryId;
+    let resolvedCategoryLabel = categoryLabel;
+
+    if (categoryId === "create") {
+      if (!newCategory.trim()) {
+        toast.error("Name your new category first");
+        return;
+      }
+      const created = addCategory({ label: newCategory.trim(), color, icon });
+      resolvedCategoryId = created.id;
+      resolvedCategoryLabel = created.label;
+      setCategoryId(created.id);
+      setCategoryLabel(created.label);
+      setNewCategory("");
+    }
+
+    addTopic({
+      title,
+      notes,
+      categoryId: resolvedCategoryId,
+      categoryLabel: resolvedCategoryLabel,
+      icon,
+      color,
+      reminderTime,
+      intervals: [...intervals].sort((a, b) => a - b)
+    });
+    toast.success("Topic saved");
+    resetForm();
+  };
+
+  const handleCreateCategory = () => {
+    if (!newCategory.trim()) return;
+    const category = addCategory({ label: newCategory.trim(), color, icon });
+    setCategoryId(category.id);
+    setCategoryLabel(category.label);
+    setNewCategory("");
+  };
+
+  const handleCategoryChange = (value: string) => {
+    if (value === "create") {
+      setCategoryId("create");
+      return;
+    }
+    setCategoryId(value);
+    const selected = categories.find((item) => item.id === value);
+    setCategoryLabel(selected?.label ?? "");
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-3xl border border-white/5 bg-white/5 p-6 shadow-lg backdrop-blur"
+    >
+      <div className="space-y-5">
+        <div className="space-y-2">
+          <Label htmlFor="topic">Topic</Label>
+          <Input
+            id="topic"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            placeholder="What do you want to remember?"
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Category</Label>
+          <Select value={categoryId ?? undefined} onValueChange={handleCategoryChange}>
+            <SelectTrigger>
+              <SelectValue placeholder="Select category" />
+            </SelectTrigger>
+            <SelectContent>
+              {categories.map((category) => (
+                <SelectItem key={category.id} value={category.id}>
+                  <span className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full" style={{ backgroundColor: category.color }} />
+                    {category.label}
+                  </span>
+                </SelectItem>
+              ))}
+              <SelectItem value="create">+ Create new</SelectItem>
+            </SelectContent>
+          </Select>
+          {categoryId === "create" ? (
+            <div className="mt-3 flex gap-2">
+              <Input
+                value={newCategory}
+                onChange={(event) => setNewCategory(event.target.value)}
+                placeholder="New category name"
+              />
+              <Button type="button" onClick={handleCreateCategory}>
+                Save
+              </Button>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <div className="space-y-2">
+            <Label>Icon</Label>
+            <IconPicker value={icon} onChange={setIcon} />
+          </div>
+          <div className="space-y-2">
+            <Label>Color</Label>
+            <ColorPicker value={color} onChange={setColor} />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="reminder">Reminder</Label>
+          <Input
+            id="reminder"
+            type="time"
+            value={reminderTime ?? ""}
+            onChange={(event) => setReminderTime(event.target.value || null)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Notes</Label>
+          <Textarea
+            value={notes}
+            onChange={(event) => setNotes(event.target.value)}
+            placeholder="Capture keywords, mnemonics, or highlights..."
+            rows={5}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label>Intervals</Label>
+          <IntervalEditor value={intervals} onChange={setIntervals} />
+        </div>
+
+        <div className="flex justify-end">
+          <Button type="submit" className="px-6">
+            Save Topic
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+};

--- a/src/components/icon-preview.tsx
+++ b/src/components/icon-preview.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+import * as Icons from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type IconPreviewProps = {
+  name: string;
+  className?: string;
+};
+
+export const IconPreview: React.FC<IconPreviewProps> = ({ name, className }) => {
+  const Icon = (Icons as Record<string, React.ComponentType<{ className?: string }>>)[name] ?? Icons.Sparkles;
+  return <Icon className={cn("h-5 w-5", className)} />;
+};

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,49 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:pointer-events-none disabled:opacity-60",
+  {
+    variants: {
+      variant: {
+        default: "bg-accent text-accent-foreground hover:bg-accent/90",
+        outline: "border border-border bg-surface hover:bg-muted",
+        ghost: "hover:bg-muted"
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-xl px-5",
+        icon: "h-10 w-10"
+      }
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default"
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type = "text", ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-surface-foreground shadow-sm transition-colors placeholder:text-zinc-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-60",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = "Input";
+
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn("text-xs font-semibold uppercase tracking-wide text-zinc-300", className)}
+    {...props}
+  />
+));
+Label.displayName = "Label";
+
+export { Label };

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,26 @@
+import * as React from "react";
+import * as PopoverPrimitive from "@radix-ui/react-popover";
+import { cn } from "@/lib/utils";
+
+const Popover = PopoverPrimitive.Root;
+
+const PopoverTrigger = PopoverPrimitive.Trigger;
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 8, ...props }, ref) => (
+  <PopoverPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 w-64 rounded-xl border border-border bg-surface/95 p-3 text-sm text-surface-foreground shadow-lg backdrop-blur",
+      className
+    )}
+    {...props}
+  />
+));
+PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+
+export { Popover, PopoverTrigger, PopoverContent };

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import { cn } from "@/lib/utils";
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root ref={ref} className={cn("relative overflow-hidden", className)} {...props}>
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" ? "h-full w-2 border-l border-l-transparent" : "h-2 border-t border-t-transparent",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-zinc-600" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+export { ScrollArea, ScrollBar };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,98 @@
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between gap-2 rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-surface-foreground shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-60",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-70" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-border bg-surface/95 text-surface-foreground shadow-lg backdrop-blur supports-[backdrop-filter]:bg-surface/80",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectPrimitive.Viewport className="p-1">
+        {children}
+      </SelectPrimitive.Viewport>
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-xs font-semibold text-zinc-400", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full select-none items-center rounded-md px-2 py-2 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
+      className
+    )}
+    {...props}
+  >
+    <span className="flex flex-1 items-center gap-2">{children}</span>
+    <SelectPrimitive.ItemIndicator className="absolute right-2 flex h-4 w-4 items-center justify-center">
+      <Check className="h-4 w-4" />
+    </SelectPrimitive.ItemIndicator>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export { Select, SelectGroup, SelectValue, SelectTrigger, SelectContent, SelectLabel, SelectItem, SelectSeparator };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
+  return (
+    <textarea
+      className={cn(
+        "flex min-h-[120px] w-full rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-surface-foreground shadow-sm transition-colors placeholder:text-zinc-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-60",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/src/hooks/use-reminder-scheduler.ts
+++ b/src/hooks/use-reminder-scheduler.ts
@@ -1,0 +1,63 @@
+"use client";
+
+import * as React from "react";
+import { useTopicStore } from "@/stores/topics";
+import { isDueToday } from "@/lib/date";
+
+const hasNotificationSupport = () => typeof window !== "undefined" && "Notification" in window;
+
+export const useReminderScheduler = () => {
+  const topics = useTopicStore((state) => state.topics);
+  const notifiedTodayRef = React.useRef<Set<string>>(new Set());
+
+  React.useEffect(() => {
+    if (!hasNotificationSupport()) return;
+    if (Notification.permission === "default") {
+      void Notification.requestPermission();
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (!hasNotificationSupport()) return;
+    if (Notification.permission !== "granted") return;
+
+    const clearNotified = () => {
+      notifiedTodayRef.current.clear();
+    };
+
+    const midnightReset = window.setInterval(() => {
+      const now = new Date();
+      if (now.getHours() === 0 && now.getMinutes() === 0) {
+        clearNotified();
+      }
+    }, 60_000);
+
+    const interval = window.setInterval(() => {
+      const now = new Date();
+      const currentTime = `${now.getHours().toString().padStart(2, "0")}:${now
+        .getMinutes()
+        .toString()
+        .padStart(2, "0")}`;
+
+      topics.forEach((topic) => {
+        if (!topic.reminderTime) return;
+        if (topic.reminderTime !== currentTime) return;
+        if (!isDueToday(topic.nextReviewDate)) return;
+
+        const key = `${topic.id}-${now.toDateString()}`;
+        if (notifiedTodayRef.current.has(key)) return;
+
+        notifiedTodayRef.current.add(key);
+        new Notification(`Review ${topic.title}`, {
+          body: `It\'s time to revisit ${topic.title}.`,
+          tag: topic.id
+        });
+      });
+    }, 60_000);
+
+    return () => {
+      window.clearInterval(interval);
+      window.clearInterval(midnightReset);
+    };
+  }, [topics]);
+};

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,31 @@
+import { IntervalPreset } from "@/types/topic";
+
+export const DEFAULT_INTERVALS: IntervalPreset[] = [
+  { id: "d1", label: "1 day", days: 1 },
+  { id: "d4", label: "4 days", days: 4 },
+  { id: "d14", label: "14 days", days: 14 },
+  { id: "d30", label: "30 days", days: 30 },
+  { id: "d60", label: "60 days", days: 60 }
+];
+
+export const ICON_OPTIONS = [
+  "BookOpen",
+  "Brain",
+  "Code",
+  "FlaskConical",
+  "Languages",
+  "Microscope",
+  "Palette",
+  "Sparkles",
+  "Target"
+];
+
+export const COLOR_OPTIONS = [
+  "#38bdf8",
+  "#22d3ee",
+  "#f97316",
+  "#f59e0b",
+  "#a855f7",
+  "#10b981",
+  "#ef4444"
+];

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,27 @@
+export const formatDate = (value: string) => {
+  const date = new Date(value);
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric"
+  }).format(date);
+};
+
+export const isDueToday = (value: string) => {
+  const today = new Date();
+  const date = new Date(value);
+  const normalizedToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  const normalizedDate = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  return normalizedDate <= normalizedToday;
+};
+
+export const formatTime = (value: string | null) => {
+  if (!value) return "No reminder";
+  const [hours, minutes] = value.split(":");
+  const date = new Date();
+  date.setHours(Number(hours));
+  date.setMinutes(Number(minutes));
+  return new Intl.DateTimeFormat("en", {
+    hour: "numeric",
+    minute: "2-digit"
+  }).format(date);
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/stores/topics.ts
+++ b/src/stores/topics.ts
@@ -1,0 +1,112 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { v4 as uuid } from "uuid";
+import { Category, Topic } from "@/types/topic";
+
+export type ReviewStatus = "due" | "scheduled" | "completed";
+
+export type TopicPayload = {
+  title: string;
+  notes: string;
+  categoryId: string | null;
+  categoryLabel: string;
+  icon: string;
+  color: string;
+  reminderTime: string | null;
+  intervals: number[];
+};
+
+type TopicStore = {
+  topics: Topic[];
+  categories: Category[];
+  addCategory: (category: Omit<Category, "id">) => Category;
+  addTopic: (payload: TopicPayload) => void;
+  updateTopic: (id: string, payload: TopicPayload) => void;
+  deleteTopic: (id: string) => void;
+  markReviewed: (id: string) => void;
+};
+
+const calculateNextReview = (
+  lastReviewedAt: string | null,
+  intervals: number[],
+  currentIndex: number
+): string => {
+  const baseDate = lastReviewedAt ? new Date(lastReviewedAt) : new Date();
+  const safeIndex = intervals.length === 0 ? 0 : Math.min(currentIndex, intervals.length - 1);
+  const nextInterval = intervals[safeIndex] ?? 1;
+  const nextDate = new Date(baseDate);
+  nextDate.setDate(baseDate.getDate() + nextInterval);
+  return nextDate.toISOString();
+};
+
+export const useTopicStore = create<TopicStore>()(
+  persist(
+    (set, get) => ({
+      topics: [],
+      categories: [
+        { id: "general", label: "General", color: "#38bdf8", icon: "Sparkles" }
+      ],
+      addCategory: (category) => {
+        const newCategory: Category = {
+          id: uuid(),
+          ...category
+        };
+        set((state) => ({ categories: [...state.categories, newCategory] }));
+        return newCategory;
+      },
+      addTopic: (payload) => {
+        const id = uuid();
+        const createdAt = new Date().toISOString();
+        const nextReviewDate = calculateNextReview(null, payload.intervals, 0);
+        const topic: Topic = {
+          id,
+          createdAt,
+          lastReviewedAt: null,
+          currentIntervalIndex: 0,
+          nextReviewDate,
+          ...payload
+        };
+        set((state) => ({ topics: [topic, ...state.topics] }));
+      },
+      updateTopic: (id, payload) => {
+        set((state) => ({
+          topics: state.topics.map((topic) =>
+            topic.id === id
+              ? {
+                  ...topic,
+                  ...payload,
+                  intervals: payload.intervals,
+                  nextReviewDate: calculateNextReview(
+                    topic.lastReviewedAt,
+                    payload.intervals,
+                    topic.currentIntervalIndex
+                  )
+                }
+              : topic
+          )
+        }));
+      },
+      deleteTopic: (id) => {
+        set((state) => ({ topics: state.topics.filter((topic) => topic.id !== id) }));
+      },
+      markReviewed: (id) => {
+        set((state) => ({
+          topics: state.topics.map((topic) => {
+            if (topic.id !== id) return topic;
+            const nextIndex = Math.min(topic.currentIntervalIndex + 1, topic.intervals.length - 1);
+            const lastReviewedAt = new Date().toISOString();
+            return {
+              ...topic,
+              currentIntervalIndex: nextIndex,
+              lastReviewedAt,
+              nextReviewDate: calculateNextReview(lastReviewedAt, topic.intervals, nextIndex)
+            };
+          })
+        }));
+      }
+    }),
+    {
+      name: "spaced-repetition-store"
+    }
+  )
+);

--- a/src/types/topic.ts
+++ b/src/types/topic.ts
@@ -1,0 +1,28 @@
+export type IntervalPreset = {
+  id: string;
+  label: string;
+  days: number;
+};
+
+export type Topic = {
+  id: string;
+  title: string;
+  notes: string;
+  categoryId: string | null;
+  categoryLabel: string;
+  icon: string;
+  color: string;
+  reminderTime: string | null;
+  intervals: number[];
+  currentIntervalIndex: number;
+  nextReviewDate: string;
+  lastReviewedAt: string | null;
+  createdAt: string;
+};
+
+export type Category = {
+  id: string;
+  label: string;
+  color: string;
+  icon: string;
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,35 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["Inter", "var(--font-inter)", "system-ui", "sans-serif"]
+      },
+      colors: {
+        surface: {
+          DEFAULT: "#0f172a",
+          foreground: "#f8fafc"
+        },
+        accent: {
+          DEFAULT: "#38bdf8",
+          foreground: "#0f172a"
+        },
+        border: "#1f2937",
+        muted: "#1e293b",
+        card: {
+          DEFAULT: "#111827",
+          foreground: "#f8fafc"
+        }
+      }
+    }
+  },
+  plugins: [require("tailwindcss-animate")]
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["./src/components/*"],
+      "@/app/*": ["./src/app/*"],
+      "@/stores/*": ["./src/stores/*"],
+      "@/lib/*": ["./src/lib/*"],
+      "@/types/*": ["./src/types/*"],
+      "@/hooks/*": ["./src/hooks/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- bootstrap a Next.js + Tailwind workspace with global styling, fonts, and linting configuration
- implement a topic composer with category management, interval editing, and rich metadata controls persisted locally via Zustand
- add a reminders-enabled dashboard that highlights due reviews and supports marking or removing topics with animated cards

## Testing
- npm install *(fails: 403 Forbidden when downloading packages in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ddeee210648331833cdb7ff2c31fd4