### PR TITLE
Add minimal documentation pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,28 @@ npm run dev
 
 Then open http://localhost:3000 in your browser.
 
+## Testing
+
+Run the lint suite to catch common issues and ensure the Playwright smoke tests still render the UI as expected:
+
+```bash
+npm run lint
+npm run test:visual
+```
+
+`npm run test:visual` launches the bundled Playwright test suite, which validates critical UI flows and ensures the primary dashboard renders without regression.
+
+## Deployment
+
+Build a production bundle and start the optimized server:
+
+```bash
+npm run build
+npm run start
+```
+
+Deployments can be hosted on any platform that supports Next.js 14 (for example, Vercel or a container image). The app persists data in the browser using Zustand's `localStorage` integration, so no external services are required.
+
 ## Tech stack
 
 - Next.js 14 (App Router)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,36 @@
+# Architecture Overview
+
+## System context
+
+The Spaced Repetition App is a local-first Next.js 14 application. All data is stored in the browser via Zustand's `localStorage` persistence, so the runtime consists solely of the Next.js server (during development) or static assets served by a CDN or Node.js server in production.
+
+```
+┌───────────┐        ┌────────────────────────┐
+│  Browser  │  HTTP  │  Next.js app (App Dir) │
+│ (React UI)├────────►│  Components & Routes   │
+└─────┬─────┘        └──────────┬────────────┘
+      │ localStorage            │ Zustand store
+      │                         ▼
+      └─────────────── Persisted topic state ──▶
+```
+
+## Key modules
+
+- **App Router (`src/app`)** – Hosts the landing dashboard and layout. Because the app is purely client-side, the primary entry point is `src/app/(pages)/page.tsx`.
+- **UI components (`src/components`)** – Presentational and form components that render topic cards, subject summaries, and controls for adjusting review intervals.
+- **State management (`src/stores/topics.ts`)** – A persisted Zustand store that encapsulates topics, subjects, and review metrics. It owns all mutations and enforces constraints (e.g., unique subject names, interval recalculation, exam date clamping).
+- **Selectors (`src/selectors`)** – Derive computed values from the store, such as dashboard summaries, to keep components lightweight.
+- **Lib utilities (`src/lib`)** – Date utilities, feature flags, and helper logic used across the app.
+
+## Data flow
+
+1. User interactions in the dashboard dispatch actions to the Zustand store (`useTopicStore`).
+2. Store mutations update in-memory state, recalculate intervals, and append timeline events.
+3. Persist middleware serializes the store into `localStorage` under the `spaced-repetition-store` key.
+4. Components subscribe to slices of state and rerender automatically when the store changes.
+
+## Deployment considerations
+
+- The project targets modern evergreen browsers; no SSR-only APIs are used.
+- Local persistence means deployments do not require a backing database, but users will lose data when clearing browser storage or switching devices.
+- Feature flags in `src/lib/feature-flags.ts` can toggle experimental behaviors without code changes elsewhere.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,43 @@
+# Runbook
+
+This runbook helps troubleshoot common production issues. Because the app is local-first, "production" usually means a static deployment (e.g., Vercel) that serves the compiled Next.js bundle.
+
+## Service overview
+
+- **App**: Next.js single-page experience served from `npm run start` or a static hosting provider.
+- **State**: User data is persisted in `localStorage` under the `spaced-repetition-store` key.
+
+## Monitoring checklist
+
+- Confirm that the deployment loads without console errors in the browser DevTools.
+- Verify that `localStorage.getItem("spaced-repetition-store")` returns data after creating a topic.
+- Check that the "Review Today" count updates when marking a topic as reviewed.
+
+## Common incidents
+
+### The dashboard renders blank
+
+1. Open the browser console and look for hydration or JavaScript errors.
+2. Clear `localStorage` for the origin to remove corrupted state.
+3. If the issue persists, redeploy using the latest `main` build and re-run Playwright smoke tests locally (`npm run test:visual`).
+
+### Topics fail to persist between refreshes
+
+1. Verify the site is served over HTTPS or `localhost` so the browser allows storage.
+2. Check browser privacy settings or extensions that might block `localStorage`.
+3. Ensure the `persist` configuration in `src/stores/topics.ts` still uses the `localStorage` storage adapter.
+
+### Review intervals look incorrect
+
+1. Confirm the subject's exam date is set correctly in the UI.
+2. Inspect `src/lib/date.ts` to ensure the interval calculation helpers have not been modified unexpectedly.
+3. Use the "Skip" control on a topic to reschedule evenly and observe whether the new schedule matches expectations.
+
+## Deployment rollback
+
+Revert to the previous deployment by re-running `npm run build` from the last known-good commit and redeploying. Because the app is static, rollbacks are typically instantaneous once the hosting provider switches the active build.
+
+## Escalation
+
+- **Primary**: Front-end developer responsible for the latest release.
+- **Secondary**: Project maintainer listed in `package.json` (update as needed).

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,0 +1,38 @@
+# Test Plan
+
+This document outlines the lightweight testing strategy for the Spaced Repetition App.
+
+## Testing scope
+
+- **Critical UI flows**: Creating topics, updating intervals, marking reviews, and verifying dashboard metrics.
+- **State integrity**: Ensuring persisted data rehydrates correctly across reloads.
+- **Visual regressions**: Guarding against major layout or interaction regressions in the dashboard.
+
+## Test types
+
+| Type | Tooling | Coverage |
+| --- | --- | --- |
+| Static analysis | `npm run lint` (ESLint + TypeScript) | Catches TypeScript errors, accessibility issues, and common React mistakes. |
+| End-to-end smoke | `npm run test:visual` (Playwright) | Launches the app, seeds sample data, and verifies that the dashboard renders with expected counts and controls. |
+| Manual exploratory | Browser session against `npm run dev` | Used before releases to validate new features, keyboard shortcuts, and responsive behavior. |
+
+## Execution cadence
+
+- **Continuous Integration**: Run `npm run lint` and `npm run test:visual` on every pull request.
+- **Release validation**: Perform a manual exploratory pass before tagging a release or pushing to production.
+- **Post-deployment**: If an incident occurs, re-run the Playwright suite locally to confirm the fix.
+
+## Environments
+
+- **Local development**: `npm run dev` (Next.js dev server)
+- **Preview/staging**: Optional Vercel preview deployment per pull request.
+- **Production**: Static hosting or `npm run start` on a Node.js server.
+
+## Test data management
+
+- Playwright tests bootstrap their own data using the Zustand store helpers. No external fixtures are required.
+- Manual testing can import/export data by copying the serialized JSON from `localStorage.getItem("spaced-repetition-store")`.
+
+## Ownership
+
+- The engineering team maintains automated tests. Contributors must update or extend Playwright specs when changing primary flows.


### PR DESCRIPTION
## Summary
- extend the README with testing and deployment instructions for the Next.js app
- add architecture, runbook, and test plan docs to capture key operational knowledge

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68df36cb39b883229f644b911d3aa250