### PR TITLE
Add quick revision modal and enhance timeline controls

### DIFF
--- a/src/components/dashboard/quick-revision-dialog.tsx
+++ b/src/components/dashboard/quick-revision-dialog.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import * as React from "react";
+import { createPortal } from "react-dom";
+import { Button } from "@/components/ui/button";
+import { X } from "lucide-react";
+
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+interface QuickRevisionDialogProps {
+  open: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+  topicTitle?: string;
+  isConfirming?: boolean;
+  /**
+   * Element to restore focus to when the dialog closes.
+   */
+  returnFocusRef?: React.RefObject<HTMLElement | null>;
+}
+
+export function QuickRevisionDialog({
+  open,
+  onConfirm,
+  onClose,
+  topicTitle,
+  isConfirming = false,
+  returnFocusRef
+}: QuickRevisionDialogProps) {
+  const [isMounted, setIsMounted] = React.useState(false);
+  const overlayRef = React.useRef<HTMLDivElement | null>(null);
+  const dialogRef = React.useRef<HTMLDivElement | null>(null);
+  const previouslyFocused = React.useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+
+    const body = document.body;
+    const previousOverflow = body.style.overflow;
+    body.style.overflow = "hidden";
+
+    const dialog = dialogRef.current;
+    if (dialog) {
+      const focusable = dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      const first = focusable[0];
+      if (first) {
+        window.requestAnimationFrame(() => first.focus());
+      }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const element = dialogRef.current;
+      if (!element) return;
+
+      const focusable = Array.from(
+        element.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((node) => !node.hasAttribute("disabled"));
+
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const current = document.activeElement as HTMLElement | null;
+
+      if (!event.shiftKey && current === last) {
+        event.preventDefault();
+        first.focus();
+      } else if (event.shiftKey && current === first) {
+        event.preventDefault();
+        last.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  React.useEffect(() => {
+    if (open) return;
+
+    const target = returnFocusRef?.current ?? previouslyFocused.current;
+    if (target) {
+      window.requestAnimationFrame(() => target.focus());
+    }
+  }, [open, returnFocusRef]);
+
+  if (!open || !isMounted) {
+    return null;
+  }
+
+  const overlay = (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-[1000] flex items-end justify-center bg-slate-950/80 px-4 pb-[max(env(safe-area-inset-bottom),16px)] pt-6 backdrop-blur-sm transition sm:items-center sm:pb-6"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === overlayRef.current) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="quick-revision-title"
+        aria-describedby="quick-revision-description"
+        className="relative w-full max-w-md rounded-3xl border border-white/10 bg-slate-900/95 p-6 text-white shadow-2xl sm:p-8"
+      >
+        <button
+          type="button"
+          className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 text-zinc-300 transition hover:text-white"
+          onClick={onClose}
+          aria-label="Close quick revision dialog"
+        >
+          <X className="h-4 w-4" />
+        </button>
+        <div className="space-y-3 pr-8">
+          <div className="inline-flex items-center gap-2 rounded-full bg-emerald-500/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-emerald-200">
+            Quick revision
+          </div>
+          <h2 id="quick-revision-title" className="text-xl font-semibold text-white">
+            Quick revision
+          </h2>
+          <p id="quick-revision-description" className="text-sm text-zinc-300">
+            {topicTitle ? (
+              <>
+                Record today’s revision for <span className="font-semibold text-white">{topicTitle}</span>. We’ll keep your scheduled reviews intact.
+              </>
+            ) : (
+              "Record today’s revision without changing your upcoming schedule."
+            )}
+          </p>
+          <p className="text-xs text-zinc-400">
+            You can log one quick revision per topic each day. Use it when you squeeze in extra practice.
+          </p>
+        </div>
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={onClose}
+            className="w-full rounded-2xl sm:w-auto"
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            onClick={onConfirm}
+            disabled={isConfirming}
+            className="w-full rounded-2xl bg-emerald-500/80 text-slate-950 transition hover:bg-emerald-400 sm:w-auto"
+          >
+            Log revision
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(overlay, document.body);
+}
+

--- a/src/components/dashboard/topic-card.tsx
+++ b/src/components/dashboard/topic-card.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { IconPreview } from "@/components/icon-preview";
 import { Button } from "@/components/ui/button";
+import { QuickRevisionDialog } from "@/components/dashboard/quick-revision-dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import {
@@ -94,6 +95,9 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = React.useState(false);
   const [showSkipConfirm, setShowSkipConfirm] = React.useState(false);
   const [showAdjustPrompt, setShowAdjustPrompt] = React.useState(false);
+  const [showQuickRevision, setShowQuickRevision] = React.useState(false);
+  const revisionTriggerRef = React.useRef<HTMLButtonElement | null>(null);
+  const [isLoggingRevision, setIsLoggingRevision] = React.useState(false);
 
   const due = isDueToday(topic.nextReviewDate);
   const reviewedToday = topic.lastReviewedAt ? isToday(topic.lastReviewedAt) : false;
@@ -241,7 +245,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
     endSavingState(setIsSavingReminder);
   };
 
-  const handleMarkReviewed = (adjustFuture?: boolean, source?: "revise-now") => {
+  const handleMarkReviewed = (adjustFuture?: boolean, source?: "revise-now"): boolean => {
     const nowIso = new Date().toISOString();
     const scheduledTime = new Date(topic.nextReviewDate).getTime();
     const nowTime = Date.now();
@@ -251,7 +255,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
       if (autoAdjustPreference === "ask") {
         pendingReviewSource.current = source;
         setShowAdjustPrompt(true);
-        return;
+        return false;
       }
       const shouldAdjust = autoAdjustPreference === "always";
       const success = markReviewed(topic.id, {
@@ -261,13 +265,12 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
         timeZone: resolvedTimezone
       });
       if (success) {
-        toast.success(
-          source === "revise-now" ? "Great job—logged today’s quick revision." : "Review recorded early"
-        );
+        toast.success(source === "revise-now" ? "Logged today’s revision" : "Review recorded early");
+        return true;
       } else if (source === "revise-now") {
         toast.error("Already used today. Try again after midnight.");
       }
-      return;
+      return false;
     }
 
     const success = markReviewed(topic.id, {
@@ -281,31 +284,47 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
       if (source === "revise-now") {
         toast.error("Already used today. Try again after midnight.");
       }
-      return;
+      return false;
     }
 
     if (source === "revise-now") {
-      toast.success("Great job—logged today’s quick revision.");
+      toast.success("Logged today’s revision");
     } else if (isEarly) {
       toast.success("Review recorded early");
     } else {
       toast.success("Great job! Schedule updated.");
     }
+
+    return true;
   };
 
-  const handleReviseNow = () => {
+  const handleReviseNow = (event?: React.MouseEvent<HTMLButtonElement>) => {
     if (hasUsedReviseToday) {
       trackReviseNowBlocked();
       toast.error("Already used today. Try again after midnight.");
       return;
     }
+    revisionTriggerRef.current = event?.currentTarget ?? null;
+    setShowQuickRevision(true);
+  };
 
+  const handleConfirmQuickRevision = () => {
+    setIsLoggingRevision(true);
     try {
-      handleMarkReviewed(undefined, "revise-now");
+      const success = handleMarkReviewed(false, "revise-now");
+      if (success) {
+        setShowQuickRevision(false);
+      }
     } catch (error) {
       console.error(error);
       toast.error("Could not record that revision. Please try again once you're back online.");
+    } finally {
+      setIsLoggingRevision(false);
     }
+  };
+
+  const handleCloseQuickRevision = () => {
+    setShowQuickRevision(false);
   };
 
   const dismissAdjustPrompt = () => {
@@ -557,7 +576,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
                 "flex-1 min-w-[180px] gap-2 rounded-2xl bg-gradient-to-r from-accent to-accent/80 text-sm font-semibold",
                 !due && hasUsedReviseToday ? "cursor-not-allowed opacity-60" : ""
               )}
-              onClick={() => (due ? handleMarkReviewed() : handleReviseNow())}
+              onClick={(event) => (due ? handleMarkReviewed() : handleReviseNow(event))}
               aria-disabled={!due && hasUsedReviseToday}
             >
               <CheckCircle2 className="h-4 w-4" />
@@ -574,7 +593,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
           </div>
           {!due && hasUsedReviseToday ? (
             <div className="space-y-1 text-right text-xs sm:text-left">
-              <p className="font-medium text-emerald-300">Great job—logged today’s quick revision.</p>
+              <p className="font-medium text-emerald-300">Logged today’s revision.</p>
               {nextAvailabilityLabel ? (
                 <p className="text-zinc-400">
                   You already revised this topic today. Available again at {nextAvailabilityLabel}.
@@ -616,6 +635,15 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
         confirmTone="danger"
         onConfirm={confirmDelete}
         icon={<Trash2 className="h-5 w-5" />}
+      />
+
+      <QuickRevisionDialog
+        open={showQuickRevision}
+        onConfirm={handleConfirmQuickRevision}
+        onClose={handleCloseQuickRevision}
+        topicTitle={topic.title}
+        isConfirming={isLoggingRevision}
+        returnFocusRef={revisionTriggerRef}
       />
 
       <ConfirmationDialog


### PR DESCRIPTION
## Summary
- add a portal-based Quick Revision dialog and wire topic cards and list rows to launch it with refreshed messaging and focus handling
- defer loading the saved list density until after mount to keep server and client renders aligned
- expand the timeline UI with keyboard and button zoom controls, timezone-aware date ticks, and a visible reset state for exports and markers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68df4528ea8083229eaf87fc8d794708