### PR TITLE
Align topic identity with subjects and sync timeline visuals

### DIFF
--- a/src/app/subjects/page.tsx
+++ b/src/app/subjects/page.tsx
@@ -162,6 +162,29 @@ const SubjectAdminPage: React.FC = () => {
                             <ColorPicker value={editDraft.color} onChange={(value) => setEditDraft((prev) => ({ ...prev, color: value }))} />
                           </div>
                         </div>
+                        <div className="rounded-2xl border border-white/10 bg-slate-900/70 p-4">
+                          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Live preview</p>
+                          <div className="mt-3 flex items-center gap-3">
+                            <span
+                              className="flex h-12 w-12 items-center justify-center rounded-2xl"
+                              style={{ backgroundColor: `${editDraft.color}22` }}
+                              aria-hidden="true"
+                            >
+                              <IconPreview name={editDraft.icon} className="h-5 w-5" />
+                            </span>
+                            <div className="text-xs text-zinc-300 space-y-1">
+                              <p>
+                                Icon: <span className="text-white">{editDraft.icon}</span>
+                              </p>
+                              <p>
+                                Colour: <span className="text-white">{editDraft.color}</span>
+                              </p>
+                              <p className="text-[11px] text-zinc-500">
+                                Saving updates every topic assigned to this subject.
+                              </p>
+                            </div>
+                          </div>
+                        </div>
                         <div className="flex items-center justify-end gap-3">
                           <Button type="button" variant="ghost" onClick={handleCancelEdit}>
                             Cancel
@@ -272,6 +295,27 @@ const SubjectAdminPage: React.FC = () => {
               <div className="space-y-2">
                 <Label>Color</Label>
                 <ColorPicker value={color} onChange={setColor} />
+              </div>
+            </div>
+            <div className="rounded-2xl border border-white/10 bg-slate-900/70 p-4">
+              <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Live preview</p>
+              <div className="mt-3 flex items-center gap-3">
+                <span
+                  className="flex h-12 w-12 items-center justify-center rounded-2xl"
+                  style={{ backgroundColor: `${color}22` }}
+                  aria-hidden="true"
+                >
+                  <IconPreview name={icon} className="h-5 w-5" />
+                </span>
+                <div className="text-xs text-zinc-300 space-y-1">
+                  <p>
+                    Icon: <span className="text-white">{icon}</span>
+                  </p>
+                  <p>
+                    Colour: <span className="text-white">{color}</span>
+                  </p>
+                  <p className="text-[11px] text-zinc-500">Topics created in this subject will use this identity.</p>
+                </div>
               </div>
             </div>
             <Button type="submit" className="w-full gap-2">

--- a/src/components/calendar/calendar-view.tsx
+++ b/src/components/calendar/calendar-view.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/lib/date";
 import { Topic } from "@/types/topic";
 import { Calendar as CalendarIcon, ChevronLeft, ChevronRight, Filter } from "lucide-react";
+import { REVISE_LOCKED_MESSAGE } from "@/lib/constants";
 import { toast } from "sonner";
 
 const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
@@ -162,7 +163,7 @@ export function CalendarView() {
       }
       const lastKey = getDayKeyInTimeZone(topic.reviseNowLastUsedAt, timezone);
       if (lastKey === todayKey) {
-        return { allowed: false, message: "Available after midnight" };
+        return { allowed: false, message: REVISE_LOCKED_MESSAGE };
       }
       return { allowed: true };
     },
@@ -180,9 +181,10 @@ export function CalendarView() {
         return;
       }
       revisionTriggerRef.current = trigger ?? null;
+      setActiveDayKey(null);
       setRevisionTopic(topic);
     },
-    [canReviseTopic, trackReviseNowBlocked]
+    [canReviseTopic, setActiveDayKey, trackReviseNowBlocked]
   );
 
   const handleConfirmRevision = React.useCallback(() => {
@@ -200,7 +202,7 @@ export function CalendarView() {
         setRevisionTopic(null);
       } else {
         trackReviseNowBlocked();
-        toast.error("Already used today. Try again after midnight.");
+        toast.error(REVISE_LOCKED_MESSAGE);
       }
     } catch (error) {
       console.error(error);

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -26,6 +26,8 @@ interface DashboardProps {
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 const SUBJECT_FILTER_STORAGE_KEY = "dashboard-subject-filter";
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? React.useLayoutEffect : React.useEffect;
 
 const computeStreak = (topics: Topic[]) => {
   const reviewDays = new Set<string>();
@@ -56,30 +58,40 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
 
   const [hideSubjectNudge, setHideSubjectNudge] = React.useState(false);
   const [statusFilter, setStatusFilter] = React.useState<StatusFilter>("all");
-  const [subjectFilter, setSubjectFilter] = React.useState<SubjectFilterValue>(null);
+  const [subjectFilter, setSubjectFilter] = React.useState<SubjectFilterValue | undefined>(
+    undefined
+  );
 
-  React.useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (typeof window === "undefined") return;
     const stored = window.localStorage.getItem(SUBJECT_FILTER_STORAGE_KEY);
-    if (!stored) return;
+    if (!stored) {
+      setSubjectFilter(null);
+      return;
+    }
     try {
       const parsed = JSON.parse(stored);
       if (Array.isArray(parsed) && parsed.every((value) => typeof value === "string")) {
         setSubjectFilter(parsed.length === 0 ? new Set<string>() : new Set<string>(parsed));
+      } else {
+        setSubjectFilter(null);
       }
     } catch {
-      // ignore malformed storage values
+      setSubjectFilter(null);
     }
   }, []);
 
   React.useEffect(() => {
     if (typeof window === "undefined") return;
+    if (typeof subjectFilter === "undefined") return;
     if (subjectFilter === null) {
       window.localStorage.removeItem(SUBJECT_FILTER_STORAGE_KEY);
     } else {
       window.localStorage.setItem(SUBJECT_FILTER_STORAGE_KEY, JSON.stringify(Array.from(subjectFilter)));
     }
   }, [subjectFilter]);
+
+  const resolvedSubjectFilter = subjectFilter ?? null;
 
   const enrichedTopics = React.useMemo<TopicListItem[]>(() => {
     const subjectMap = new Map<string, Subject>();
@@ -181,10 +193,13 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
   const filteredTopicsForPlan = React.useMemo(() => {
     return enrichedTopics.filter((item) => {
       const matchesStatus = statusFilter === "all" ? true : item.status === statusFilter;
-      const matchesSubject = subjectFilter === null ? true : subjectFilter.has(item.subject?.id ?? NO_SUBJECT_KEY);
+      const matchesSubject =
+        resolvedSubjectFilter === null
+          ? true
+          : resolvedSubjectFilter.has(item.subject?.id ?? NO_SUBJECT_KEY);
       return matchesStatus && matchesSubject;
     });
-  }, [enrichedTopics, statusFilter, subjectFilter]);
+  }, [enrichedTopics, statusFilter, resolvedSubjectFilter]);
 
   const filteredDueCount = React.useMemo(
     () => filteredTopicsForPlan.filter((item) => item.status !== "upcoming").length,
@@ -217,7 +232,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
   }, []);
 
   const handleSubjectFilterChange = React.useCallback((value: SubjectFilterValue) => {
-    setSubjectFilter(value === null ? null : new Set(value));
+    setSubjectFilter(value === null ? null : new Set<string>(value));
   }, []);
 
   const handleStatusFilterChange = React.useCallback((value: StatusFilter) => {
@@ -324,7 +339,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
               zonedNow={zonedNow}
               statusFilter={statusFilter}
               onStatusFilterChange={handleStatusFilterChange}
-              subjectFilter={subjectFilter}
+              subjectFilter={resolvedSubjectFilter}
               onSubjectFilterChange={handleSubjectFilterChange}
             />
           </div>
@@ -342,7 +357,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
           </div>
         </div>
 
-        <TimelinePanel subjectFilter={subjectFilter} />
+        <TimelinePanel subjectFilter={resolvedSubjectFilter} />
       </div>
     </section>
   );
@@ -434,11 +449,14 @@ const PersonalizedReviewPlanModule = ({
       <div className="space-y-4">
         <div>
           <h2 className="text-lg font-semibold text-white">Personalized review plan</h2>
-          <p className="text-sm text-zinc-300">Your next five minutes matter</p>
+          <p className="text-sm text-zinc-300">Your next five minutes matter.</p>
         </div>
         <div className="space-y-2 text-sm text-zinc-300">
           {dueCount === 0 ? (
-            <p>Great work! You’ve completed today’s reviews. Here’s what’s coming next.</p>
+            <>
+              <p className="text-white">Great work! You’ve completed today’s reviews.</p>
+              <p>Here’s what’s coming next.</p>
+            </>
           ) : (
             <p>Stay in rhythm — log today’s reviews to keep your streak alive.</p>
           )}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -33,3 +33,5 @@ export const REMINDER_TIME_OPTIONS = [
   { value: "custom", label: "Custom time (set below)" },
   { value: "none", label: "No reminder" }
 ] as const;
+
+export const REVISE_LOCKED_MESSAGE = "You’ve already revised this today. Available again after midnight.";


### PR DESCRIPTION
## Summary
- collapse the topic wizard to three steps that inherit icon and colour from the selected subject and drop per-topic overrides
- ensure subject identity changes propagate through stored topics and refresh dashboard surfaces, including the timeline series colours
- add live subject identity previews on the Subjects page so creators can confirm icon and colour updates before saving

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68df7ee706648322ac5b3cfe5d11c034