### PR TITLE
Implement forgetting-curve scheduling and risk-driven daily plan

### DIFF
--- a/docs/forgetting-curve.md
+++ b/docs/forgetting-curve.md
@@ -1,0 +1,79 @@
+# Forgetting Curve Scheduling Model
+
+Our scheduler uses an explicit exponential forgetting curve to determine when each topic should be reviewed.
+
+## Retention model
+
+- **Retrievability** (probability of recalling a topic without help) decays as `R(t) = e^{-(t / S)}` where:
+  - `t` is the elapsed time since the last review (in days).
+  - `S` is the topic’s current *stability* in days.
+- We schedule the next review when `R(t)` is predicted to hit a configurable target `R*` (default `0.7`).
+  - The interval in days is `Δ = -S · ln(R*)`.
+  - Example intervals with `R* = 0.7`:
+    - `S = 1.0` → `Δ ≈ 0.3567` days (≈ 8.6 hours).
+    - `S = 2.0` → `Δ ≈ 0.7133` days (≈ 17.1 hours).
+    - `S = 5.0` → `Δ ≈ 1.7834` days (≈ 42.8 hours).
+  - With `R* = 0.8`, `S = 2.0` → `Δ ≈ 0.4463` days (≈ 10.7 hours).
+  - With `R* = 0.6`, `S = 1.0` → `Δ ≈ 0.5108` days (≈ 12.3 hours).
+- After each review we adjust stability using the scored quality `q ∈ {0, 0.5, 1}`:
+  - `S_new = clamp(S_old · (1 + α · (q − 0.5)), S_min, S_max)`.
+  - Defaults: `α = 1`, `S_min = 0.25d`, `S_max = 3650d`.
+- Subject difficulty modifiers scale the stability (`S_eff = S · d`) with `d ∈ [0.5, 1.5]` before interval calculation.
+- All scheduling happens in UTC timestamps but “today” boundaries use the learner’s profile timezone (Asia/Colombo by default).
+
+```mermaid
+flowchart TD
+  A[After review with quality q] --> B[Update stability S]
+  B --> C[Compute Δ = -S · ln(R*)]
+  C --> D[Clamp to ≤ exam date]
+  D --> E[Apply load smoothing (±1-2 days if needed)]
+  E --> F[Persist next_review_at and refresh UI]
+```
+
+## Stored data
+
+| Entity | Fields used by the scheduler |
+| --- | --- |
+| **Topic** | `stability`, `retrievabilityTarget`, `lastReviewedAt`, `nextReviewDate`, `reviewsCount`, `subjectDifficultyModifier`, `events[]` |
+| **Event (review)** | `at`, `reviewQuality`, `reviewKind`, `resultingStability`, `targetRetrievability`, `nextReviewAt`, `intervalDays` |
+| **Event (skip)** | `at`, `reviewKind`, `nextReviewAt` |
+| **Subject** | `examDate`, `difficultyModifier`, `color`, `icon` |
+
+Events capture the full review history so the timeline can plot the retention curve and show checkpoints.
+
+## Risk scoring (daily ordering)
+
+Topics are prioritised by a blended risk score:
+
+```
+score = 0.55·(1 − R_now) + 0.25·overdue + 0.15·exam + 0.05·difficulty
+```
+
+- `R_now` is the current retrievability (`e^{-(Δt/S_eff)}`) where `Δt` is the age of the memory.
+- `overdue = min(1, overdue_days / 3)` penalises late items.
+- `exam = min(1, 1 / max(1, days_to_exam))` nudges subjects with imminent exams.
+- `difficulty` adds 0.15 when recent quality scores fall below 0.75 and +0.05 for the first three reviews.
+
+Sorting the home list by this score makes overdue or shaky memories float to the top while safe items drift down.
+
+## Daily state machine
+
+Topics can appear in Today’s plan at most once per local day. Manual or automatic skips push them forward while respecting exam dates.
+
+```mermaid
+stateDiagram-v2
+  [*] --> AvailableToday
+  AvailableToday --> Completed: Revise (once per local day)
+  AvailableToday --> Skipped: "Skip today"
+  AvailableToday --> Skipped: Auto-skip at local midnight
+  Completed --> [*]
+  Skipped --> [*]
+```
+
+## Smoothing & safeguards
+
+- Load smoothing checks the daily cap (20 items by default) and nudges low-risk topics ±1–2 days while keeping exam constraints.
+- Midnight auto-skip rolls unfinished items into the next light day and surfaces a banner summarising the move.
+- Early reviews prompt whether to stretch future intervals or keep the original plan.
+
+These rules ensure the timeline, calendar, and daily plan remain consistent with the forgetting-curve math while keeping the learner’s workload manageable.

--- a/src/components/dashboard/topic-card.tsx
+++ b/src/components/dashboard/topic-card.tsx
@@ -189,7 +189,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
   }, [topic.reminderTime, topic.id]);
 
   const buildPayload = React.useCallback(
-    (overrides: Partial<Omit<Topic, "id" | "events" | "forgetting">>) => ({
+    (overrides: Partial<Omit<Topic, "id" | "events">>) => ({
       title: overrides.title ?? topic.title,
       notes: overrides.notes ?? topic.notes ?? "",
       subjectId: overrides.subjectId ?? topic.subjectId ?? null,
@@ -476,6 +476,9 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
                 {formatDateWithWeekday(topic.nextReviewDate)}
               </p>
               <p className="text-xs text-zinc-400">{statusStyles[currentStatus].helper}</p>
+              <p className="text-[11px] text-zinc-500">
+                Retention target ≈ {Math.round(topic.retrievabilityTarget * 100)}%
+              </p>
             </div>
           </div>
 
@@ -663,7 +666,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
         open={showAdjustPrompt}
         onClose={dismissAdjustPrompt}
         title="You studied this earlier than planned"
-        description="Adjust future intervals to reflect your progress?"
+        description="You reviewed earlier than planned. Adjust future schedule?"
         confirmLabel="Adjust schedule"
         cancelLabel="Keep original plan"
         onConfirm={() => {

--- a/src/components/dashboard/topic-list.tsx
+++ b/src/components/dashboard/topic-list.tsx
@@ -10,6 +10,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { IconPreview } from "@/components/icon-preview";
 import { useTopicStore } from "@/stores/topics";
 import { Subject, Topic } from "@/types/topic";
+import type { RiskScore } from "@/lib/forgetting-curve";
 import {
   AlertTriangle,
   CalendarClock,
@@ -45,6 +46,7 @@ export interface TopicListItem {
   topic: Topic;
   subject: Subject | null;
   status: TopicStatus;
+  risk: RiskScore;
 }
 
 export type StatusFilter = "all" | TopicStatus;
@@ -336,6 +338,9 @@ export function TopicList({
               (new Date(a.topic.lastReviewedAt ?? 0).getTime() || 0);
           case "next":
           default:
+            if (a.risk.score !== b.risk.score) {
+              return b.risk.score - a.risk.score;
+            }
             return new Date(a.topic.nextReviewDate).getTime() - new Date(b.topic.nextReviewDate).getTime();
         }
       });

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -2,12 +2,15 @@
 
 import * as React from "react";
 import { NavigationBar } from "@/components/layout/navigation-bar";
+import { useAutoSkipOverdue } from "@/hooks/use-auto-skip";
 
 interface AppShellProps {
   children: React.ReactNode;
 }
 
 export const AppShell: React.FC<AppShellProps> = ({ children }) => {
+  useAutoSkipOverdue();
+
   return (
     <div className="flex min-h-screen flex-col bg-surface text-surface-foreground">
       <NavigationBar />

--- a/src/components/visualizations/timeline-chart.tsx
+++ b/src/components/visualizations/timeline-chart.tsx
@@ -8,7 +8,13 @@ export type TimelineSeries = {
   topicTitle: string;
   color: string;
   points: { t: number; r: number }[];
-  events: { id: string; t: number; type: "started" | "reviewed" | "skipped"; intervalDays?: number; notes?: string }[];
+  events: {
+    id: string;
+    t: number;
+    type: "started" | "reviewed" | "skipped" | "checkpoint";
+    intervalDays?: number;
+    notes?: string;
+  }[];
 };
 
 export type TimelineExamMarker = {
@@ -341,7 +347,7 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
           topic: string;
           time: number;
           retention?: number;
-          type?: "started" | "reviewed" | "skipped";
+          type?: "started" | "reviewed" | "skipped" | "checkpoint";
           intervalDays?: number;
           notes?: string;
         }
@@ -815,6 +821,19 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
                   onMouseEnter={handleFocus}
                   onMouseLeave={hideTooltip}
                 />
+              ) : event.type === "checkpoint" ? (
+                <circle
+                  r={6}
+                  fill="white"
+                  stroke={line.color}
+                  strokeWidth={2}
+                  tabIndex={0}
+                  aria-label={`${line.topicTitle} checkpoint ${tooltipDateFormatter.format(new Date(event.t))}`}
+                  onFocus={handleFocus}
+                  onBlur={hideTooltip}
+                  onMouseEnter={handleFocus}
+                  onMouseLeave={hideTooltip}
+                />
               ) : (
                 <circle
                   r={5}
@@ -1162,7 +1181,13 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
                   )}
                   {tooltip.type && (
                     <div>
-                      Event: {tooltip.type === "started" ? "Started" : tooltip.type === "skipped" ? "Skipped" : "Reviewed"}
+                      Event: {tooltip.type === "started"
+                        ? "Started"
+                        : tooltip.type === "skipped"
+                        ? "Skipped"
+                        : tooltip.type === "checkpoint"
+                        ? "Checkpoint"
+                        : "Reviewed"}
                     </div>
                   )}
                   {typeof tooltip.intervalDays !== "undefined" && (

--- a/src/hooks/use-auto-skip.ts
+++ b/src/hooks/use-auto-skip.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import * as React from "react";
+import { toast } from "sonner";
+import { useTopicStore } from "@/stores/topics";
+import { useProfileStore } from "@/stores/profile";
+import { getDayKeyInTimeZone, nowInTimeZone } from "@/lib/date";
+
+export const useAutoSkipOverdue = () => {
+  const autoSkip = useTopicStore((state) => state.autoSkipOverdueTopics);
+  const timezone = useProfileStore((state) => state.profile.timezone) || "Asia/Colombo";
+
+  React.useEffect(() => {
+    let lastKey = getDayKeyInTimeZone(new Date(), timezone);
+
+    const interval = window.setInterval(() => {
+      const zonedNow = nowInTimeZone(timezone);
+      const currentKey = getDayKeyInTimeZone(zonedNow, timezone);
+      if (currentKey === lastKey) {
+        return;
+      }
+      lastKey = currentKey;
+      const results = autoSkip(timezone);
+      if (results.length > 0) {
+        const count = results.length;
+        toast.info("Daily roll-over", {
+          description:
+            count === 1
+              ? "We nudged one unfinished review into your upcoming plan."
+              : `We nudged ${count} unfinished reviews into your upcoming plan.`,
+          duration: 6000
+        });
+      }
+    }, 60_000);
+
+    return () => window.clearInterval(interval);
+  }, [autoSkip, timezone]);
+};

--- a/src/lib/forgetting-curve.ts
+++ b/src/lib/forgetting-curve.ts
@@ -1,0 +1,136 @@
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+export const DEFAULT_RETRIEVABILITY_TARGET = 0.7;
+export const DEFAULT_STABILITY_DAYS = 1;
+export const STABILITY_MIN_DAYS = 0.25;
+export const STABILITY_MAX_DAYS = 3650;
+export const STABILITY_ADJUSTMENT_ALPHA = 1.0;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+export const computeRetrievability = (stabilityDays: number, elapsedMs: number): number => {
+  const safeStability = Math.max(stabilityDays, STABILITY_MIN_DAYS);
+  const elapsedDays = Math.max(0, elapsedMs) / DAY_IN_MS;
+  const retention = Math.exp(-elapsedDays / safeStability);
+  if (!Number.isFinite(retention)) {
+    return 0;
+  }
+  return clamp(retention, 0, 1);
+};
+
+export const computeIntervalDays = (
+  stabilityDays: number,
+  targetRetrievability: number
+): number => {
+  const safeTarget = clamp(targetRetrievability, 0.01, 0.99);
+  const safeStability = Math.max(stabilityDays, STABILITY_MIN_DAYS);
+  const interval = -safeStability * Math.log(safeTarget);
+  return Math.max(interval, STABILITY_MIN_DAYS / 24);
+};
+
+export type ReviewQuality = 0 | 0.5 | 1;
+
+export const updateStability = (
+  stabilityDays: number,
+  quality: ReviewQuality,
+  alpha = STABILITY_ADJUSTMENT_ALPHA,
+  min = STABILITY_MIN_DAYS,
+  max = STABILITY_MAX_DAYS
+): number => {
+  const delta = alpha * (quality - 0.5);
+  const next = stabilityDays * (1 + delta);
+  return clamp(next, min, max);
+};
+
+export const computeOverduePenalty = (overdueDays: number) => {
+  if (overdueDays <= 0) return 0;
+  return Math.min(1, overdueDays / 3);
+};
+
+export const computeExamUrgency = (daysToExam: number | null) => {
+  if (daysToExam === null) return 0;
+  if (!Number.isFinite(daysToExam)) return 0;
+  if (daysToExam < 0) {
+    return 1;
+  }
+  const normalized = 1 / Math.max(1, daysToExam);
+  return Math.min(1, normalized);
+};
+
+export interface RiskScoreOptions {
+  now: Date;
+  stabilityDays: number;
+  targetRetrievability: number;
+  lastReviewedAt: string | null;
+  nextReviewAt: string;
+  reviewsCount: number;
+  averageQuality: number | null;
+  examDate?: string | null;
+  difficultyModifier?: number | null;
+}
+
+export const computeRiskScore = ({
+  now,
+  stabilityDays,
+  targetRetrievability,
+  lastReviewedAt,
+  nextReviewAt,
+  reviewsCount,
+  averageQuality,
+  examDate,
+  difficultyModifier
+}: RiskScoreOptions) => {
+  const nowMs = now.getTime();
+  const lastReviewMs = lastReviewedAt ? new Date(lastReviewedAt).getTime() : null;
+  const nextReviewMs = new Date(nextReviewAt).getTime();
+
+  const effectiveStability = Math.max(stabilityDays * (difficultyModifier ?? 1), STABILITY_MIN_DAYS);
+  const elapsedMs = lastReviewMs ? nowMs - lastReviewMs : 0;
+  const retrievabilityNow = computeRetrievability(effectiveStability, elapsedMs);
+  const forgettingRisk = 1 - retrievabilityNow;
+
+  const overdueMs = nowMs - nextReviewMs;
+  const overdueDays = overdueMs / DAY_IN_MS;
+  const overduePenalty = computeOverduePenalty(overdueDays);
+
+  let daysToExam: number | null = null;
+  if (examDate) {
+    const examMs = new Date(examDate).getTime();
+    if (Number.isFinite(examMs)) {
+      daysToExam = Math.round((examMs - nowMs) / DAY_IN_MS);
+    }
+  }
+
+  const examUrgency = computeExamUrgency(daysToExam);
+
+  let difficultyBump = 0;
+  if (typeof averageQuality === "number" && averageQuality < 0.75) {
+    difficultyBump += 0.15;
+  }
+  if (reviewsCount < 3) {
+    difficultyBump += 0.05;
+  }
+
+  const score =
+    0.55 * forgettingRisk + 0.25 * overduePenalty + 0.15 * examUrgency + 0.05 * difficultyBump;
+
+  return {
+    score,
+    forgettingRisk,
+    overduePenalty,
+    examUrgency,
+    difficultyBump,
+    retrievabilityNow,
+    intervalDays: computeIntervalDays(effectiveStability, targetRetrievability)
+  };
+};
+
+export type RiskScore = ReturnType<typeof computeRiskScore>;
+
+export const getAverageQuality = (qualities: number[]): number | null => {
+  if (qualities.length === 0) return null;
+  const total = qualities.reduce((sum, value) => sum + value, 0);
+  return total / qualities.length;
+};
+
+export const DAY_MS = DAY_IN_MS;

--- a/src/selectors/curves.ts
+++ b/src/selectors/curves.ts
@@ -1,89 +1,62 @@
 import { Topic, TopicEvent } from "@/types/topic";
+import { DAY_MS, STABILITY_MIN_DAYS, computeRetrievability } from "@/lib/forgetting-curve";
 
 export interface CurveSegment {
   topicId: string;
-  from: TopicEvent;
-  to?: TopicEvent;
-  tauHours: number;
-  beta: number;
+  start: TopicEvent;
+  endAt: string;
+  stabilityDays: number;
+  target: number;
 }
-
-const DEFAULT_CFG = {
-  beta: 1.0,
-  strategy: "reviews" as const,
-  baseHalfLifeHours: 12,
-  growthPerSuccessfulReview: 2.0
-};
 
 const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
 
-const calcTau = (topic: Topic, events: TopicEvent[], startIndex: number): number => {
-  const cfg = { ...DEFAULT_CFG, ...(topic.forgetting ?? {}) };
-  if (cfg.strategy === "interval") {
-    const nextEvent = events[startIndex + 1];
-    const fallbackDays = topic.intervals?.[topic.intervalIndex] ?? topic.intervals?.[0] ?? 1;
-    const intervalDays = nextEvent?.intervalDays ?? fallbackDays;
-    const estimatedHours = 0.5 * intervalDays * 24;
-    return clamp(estimatedHours, 8, 24 * 180);
+const cloneEvent = (topic: Topic, at: string): TopicEvent => ({
+  id: `${topic.id}-synthetic-${at}`,
+  topicId: topic.id,
+  type: "reviewed",
+  at,
+  intervalDays: (new Date(topic.nextReviewDate).getTime() - new Date(at).getTime()) / DAY_MS,
+  reviewKind: "scheduled",
+  reviewQuality: 1,
+  resultingStability: topic.stability,
+  targetRetrievability: topic.retrievabilityTarget,
+  nextReviewAt: topic.nextReviewDate,
+  backfill: true
+});
+
+const ensureSegmentsForTopic = (topic: Topic): CurveSegment[] => {
+  const reviewEvents = [...(topic.events ?? [])]
+    .filter((event) => event.type === "reviewed")
+    .sort((a, b) => new Date(a.at).getTime() - new Date(b.at).getTime());
+
+  if (reviewEvents.length === 0) {
+    const anchor = topic.lastReviewedAt ?? topic.startedAt ?? topic.createdAt;
+    const synthetic = cloneEvent(topic, anchor);
+    return [
+      {
+        topicId: topic.id,
+        start: synthetic,
+        endAt: topic.nextReviewDate,
+        stabilityDays: topic.stability,
+        target: topic.retrievabilityTarget
+      }
+    ];
   }
 
-  const cutoff = new Date(events[startIndex].at).getTime();
-  const reviewsSoFar = events.filter(
-    (event) => event.type === "reviewed" && new Date(event.at).getTime() <= cutoff
-  ).length;
-  const base = cfg.baseHalfLifeHours ?? DEFAULT_CFG.baseHalfLifeHours;
-  const growth = cfg.growthPerSuccessfulReview ?? DEFAULT_CFG.growthPerSuccessfulReview;
-  return base * Math.pow(growth, reviewsSoFar);
-};
-
-const topicCache = new Map<string, { hash: string; segments: CurveSegment[] }>();
-
-// Helper function to serialize TopicEvent for hash construction
-function serializeEventForHash(event: TopicEvent): string {
-  return `${event.id}:${event.at}:${event.intervalDays ?? ""}`;
-}
-
-const hashTopic = (topic: Topic): string => {
-  const events = topic.events ?? [];
-  const eventKey = events.map(serializeEventForHash).join("|");
-  const forgettingKey = `${topic.forgetting?.beta ?? DEFAULT_CFG.beta}-${topic.forgetting?.strategy ?? DEFAULT_CFG.strategy}-${topic.forgetting?.baseHalfLifeHours ?? DEFAULT_CFG.baseHalfLifeHours}-${topic.forgetting?.growthPerSuccessfulReview ?? DEFAULT_CFG.growthPerSuccessfulReview}`;
-  const intervalKey = `${topic.intervalIndex}|${(topic.intervals ?? []).join(",")}`;
-  return `${topic.id}-${eventKey}-${forgettingKey}-${intervalKey}`;
-};
-
-const computeSegmentsForTopic = (topic: Topic): CurveSegment[] => {
-  const orderedEvents = [...(topic.events ?? [])].sort(
-    (a, b) => new Date(a.at).getTime() - new Date(b.at).getTime()
-  );
-  if (orderedEvents.length === 0) return [];
-  const segments: CurveSegment[] = [];
-  for (let index = 0; index < orderedEvents.length; index += 1) {
-    const from = orderedEvents[index];
-    const to = orderedEvents[index + 1];
-    const tauHours = calcTau(topic, orderedEvents, index);
-    segments.push({
-      topicId: topic.id,
-      from,
-      to,
-      tauHours,
-      beta: topic.forgetting?.beta ?? DEFAULT_CFG.beta
-    });
-  }
-  return segments;
+  return reviewEvents.map((event) => ({
+    topicId: topic.id,
+    start: event,
+    endAt: event.nextReviewAt ?? topic.nextReviewDate,
+    stabilityDays: event.resultingStability ?? topic.stability,
+    target: event.targetRetrievability ?? topic.retrievabilityTarget
+  }));
 };
 
 export const buildCurveSegments = (topics: Topic[]): CurveSegment[] => {
   const segments: CurveSegment[] = [];
   for (const topic of topics) {
-    const hash = hashTopic(topic);
-    const cached = topicCache.get(topic.id);
-    if (cached && cached.hash === hash) {
-      segments.push(...cached.segments);
-      continue;
-    }
-    const computed = computeSegmentsForTopic(topic);
-    topicCache.set(topic.id, { hash, segments: computed });
-    segments.push(...computed);
+    segments.push(...ensureSegmentsForTopic(topic));
   }
   return segments;
 };
@@ -92,23 +65,24 @@ export const sampleSegment = (
   segment: CurveSegment,
   maxPoints = 160
 ): { t: number; r: number }[] => {
-  const startTs = new Date(segment.from.at).getTime();
-  const endTs = segment.to ? new Date(segment.to.at).getTime() : Date.now();
+  const startTs = new Date(segment.start.at).getTime();
+  const endTs = new Date(segment.endAt).getTime();
   const durationMs = Math.max(60_000, endTs - startTs);
-  const targetPoints = clamp(maxPoints, 16, 320);
-  const stepMs = durationMs / targetPoints;
+  const pointsCount = clamp(maxPoints, 16, 320);
+  const stepMs = durationMs / pointsCount;
+  const stability = Math.max(segment.stabilityDays, STABILITY_MIN_DAYS);
   const points: { t: number; r: number }[] = [];
+
   for (let ts = startTs; ts <= endTs; ts += stepMs) {
-    const elapsedHours = (ts - startTs) / 3_600_000;
-    const ratio = elapsedHours / Math.max(0.001, segment.tauHours);
-    const retention = Math.exp(-Math.pow(ratio, segment.beta));
+    const elapsedMs = ts - startTs;
+    const retention = computeRetrievability(stability, elapsedMs);
     points.push({ t: ts, r: clamp(retention, 0, 1) });
   }
+
   if (!points.some((point) => point.t === endTs)) {
-    const elapsedHours = (endTs - startTs) / 3_600_000;
-    const ratio = elapsedHours / Math.max(0.001, segment.tauHours);
-    const retention = Math.exp(-Math.pow(ratio, segment.beta));
+    const retention = computeRetrievability(stability, endTs - startTs);
     points.push({ t: endTs, r: clamp(retention, 0, 1) });
   }
+
   return points;
 };

--- a/src/types/topic.ts
+++ b/src/types/topic.ts
@@ -1,5 +1,9 @@
 ﻿export type TopicEventType = "started" | "reviewed" | "skipped";
 
+export type ReviewKind = "scheduled" | "revise_now" | "skip_user" | "skip_auto";
+
+export type ReviewQuality = 0 | 0.5 | 1;
+
 export interface TopicEvent {
   id: string;
   topicId: string;
@@ -8,16 +12,14 @@ export interface TopicEvent {
   intervalDays?: number;
   notes?: string;
   backfill?: boolean;
+  reviewKind?: ReviewKind;
+  reviewQuality?: ReviewQuality;
+  resultingStability?: number;
+  targetRetrievability?: number;
+  nextReviewAt?: string;
 }
 
 export type AutoAdjustPreference = "always" | "never" | "ask";
-
-export interface TopicForgettingConfig {
-  beta?: number;
-  strategy?: "reviews" | "interval";
-  baseHalfLifeHours?: number;
-  growthPerSuccessfulReview?: number;
-}
 
 export type Subject = {
   id: string;
@@ -25,6 +27,7 @@ export type Subject = {
   color: string;
   icon: string;
   examDate?: string | null;
+  difficultyModifier?: number | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -51,11 +54,14 @@ export type Topic = {
   nextReviewDate: string;
   lastReviewedAt: string | null;
   lastReviewedOn?: string | null;
+  stability: number;
+  retrievabilityTarget: number;
+  reviewsCount: number;
+  subjectDifficultyModifier?: number | null;
   autoAdjustPreference?: AutoAdjustPreference;
   createdAt: string;
   startedAt?: string;
   startedOn?: string | null;
   events?: TopicEvent[];
-  forgetting?: TopicForgettingConfig;
   reviseNowLastUsedAt?: string | null;
 };


### PR DESCRIPTION
## Summary
- replace the interval-based scheduler with a forgetting-curve model that tracks stability, retrievability targets, and risk scoring
- update dashboard sorting, topic cards, and timeline visuals to explain retention checkpoints and surface higher-risk topics first
- add automatic midnight skip handling plus documentation that describes the math, stored data, and daily state machine

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68dfc8e072788322961aeeb4737e9ac1