### PR TITLE
Add community documentation and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+Steps to reproduce the behaviour:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected behaviour
+A clear and concise description of what you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+- OS: [e.g. macOS 14]
+- Browser: [e.g. Chrome 124]
+- App version / commit: [e.g. 1.0.0 or `abc1234`]
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security reports
+    url: mailto:security@spacedrepetition.app
+    about: Please report security vulnerabilities privately via email.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+## Summary
+Describe the feature you would like to see.
+
+## Problem statement
+Explain the problem this feature would solve or the use case it unlocks.
+
+## Proposed solution
+Describe how you think the feature should work. Include UI sketches, workflow notes, or API ideas if helpful.
+
+## Alternatives considered
+List any alternative solutions or features you've considered.
+
+## Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+- Describe the change and why it is needed.
+- Link to any relevant issues.
+
+## Testing
+- [ ] `npm run lint`
+- [ ] `npm run test:visual`
+- [ ] Other (please describe)
+
+## Screenshots
+If the change affects the UI, add before/after screenshots or recordings.
+
+## Deployment considerations
+Note any migrations, environment changes, or follow-up tasks required after merge.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,71 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience.
+- Focusing on what is best for the community.
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when an individual is officially representing the project or its community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the maintainers at `security@spacedrepetition.app`. All complaints will be reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Project maintainers will follow these Community Impact Guidelines when determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+Community Impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+Consequence: A private, written warning from project maintainers, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+Community Impact: A violation through a single incident or series of actions.
+
+Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+Community Impact: A serious violation of community standards, including sustained inappropriate behavior.
+
+Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+Community Impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+Consequence: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing Guide
+
+Thanks for your interest in helping improve the Spaced Repetition App! This document outlines how to get started, how we review changes, and the standards we hold for contributions.
+
+## Getting Set Up
+
+1. Fork the repository and clone your fork locally.
+2. Install dependencies with `npm install`.
+3. Run `npm run dev` to start the development server.
+4. Execute `npm run lint` and `npm run test:visual` before submitting a pull request to catch issues early.
+
+## Branching and Commits
+
+- Create feature branches from `main` using a descriptive name (for example, `feature/timeline-zoom`).
+- Keep commits focused and write clear commit messages explaining the intent of each change.
+- Rebase onto the latest `main` before opening a pull request to avoid merge conflicts.
+
+## Pull Requests
+
+- Describe the change, motivation, and testing in the pull request template.
+- Reference any related issues and include screenshots or screen recordings when UI changes are made.
+- Ensure the pull request remains scoped to a single feature or fix. Open multiple PRs for unrelated changes.
+
+## Code Style
+
+- Write TypeScript using strict typing and prefer existing utility helpers where available.
+- Keep components small and composable; colocate unit tests alongside the code they cover.
+- Follow Tailwind conventions already established in the codebase and use design tokens defined in `tailwind.config.ts`.
+
+## Documentation
+
+- Update relevant docs in `docs/` and the README when behaviour or configuration changes.
+- Provide release notes or migration guidance if the change alters user-facing workflows.
+
+## Communication
+
+If you have questions, open a GitHub Discussion or start a draft PR for early feedback. For sensitive issues, contact the maintainers at `security@spacedrepetition.app`.
+
+We appreciate every contribution—thank you for helping build a better study companion!

--- a/DESCRIPTION.md
+++ b/DESCRIPTION.md
@@ -1,0 +1,12 @@
+# Project Description
+
+The Spaced Repetition App is a local-first study companion that helps learners capture topics, organise them by subject, and revisit material at the right time. Built with Next.js, Tailwind CSS, and Zustand, the app keeps data in the browser so revision sessions remain private and fast.
+
+Key capabilities include:
+
+- Subject-centric dashboards that keep colours, icons, and exam dates consistent everywhere.
+- Topic editors with spaced-review scheduling, manual history backfill, and daily review limits.
+- Calendar, timeline, and analytics views that visualise upcoming workload and exams.
+- A resilient offline-first architecture with predictable deployments and end-to-end UI tests.
+
+For quick-start instructions, testing notes, and architectural background, see the [README](README.md) and the `docs/` directory.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2024 Spaced Repetition App Maintainers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,16 @@ The Spaced Repetition App is a local-first study companion built with Next.js, T
 
 ## Quick links
 
+- [Project description](DESCRIPTION.md)
 - [Architecture](docs/architecture.md)
 - [Runbook](docs/runbook.md)
 - [Test plan](docs/test-plan.md)
 - [Security notes](docs/security.md)
 - [OpenAPI stewardship](docs/openapi.yaml)
 - [UI style audit](docs/ui-style-audit.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Contributing guide](CONTRIBUTING.md)
+- [Security policy](SECURITY.md)
 
 ## What changed recently
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported Versions
+
+We aim to keep the `main` branch secure with timely dependency updates and security patches. Please use the latest tagged release or the current `main` branch for the most up-to-date fixes.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please email `security@spacedrepetition.app` with the details. Include:
+
+- A description of the vulnerability and potential impact.
+- Steps to reproduce the issue.
+- Any suggested remediation or patches.
+
+We will acknowledge receipt within 72 hours and work with you to assess the report. Once the fix is ready, we will coordinate disclosure and credit you (if desired).
+
+## Disclosure Policy
+
+- Please do not publicly disclose vulnerabilities before we have had a reasonable chance to release a fix.
+- We prioritise security issues over feature work and will provide status updates until the issue is resolved.
+
+Thank you for helping keep the Spaced Repetition App secure!


### PR DESCRIPTION
## Summary
- add project description, contributing, conduct, license, and security policy documents
- document quick links in the README to new community resources
- provide issue templates and a pull request template for GitHub workflows

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68e09cca1778832d990ef06fca2a4acb