### PR TITLE
Clamp timeline retention curves to present

### DIFF
--- a/src/components/visualizations/timeline-chart.tsx
+++ b/src/components/visualizations/timeline-chart.tsx
@@ -21,7 +21,6 @@ export type TimelineStitch = {
 export type TimelineNowPoint = {
   t: number;
   r: number;
-  zeroHorizon: number;
   notes?: string;
 };
 
@@ -925,19 +924,13 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
             const x = scaleX(line.nowPoint!.t);
             const y = scaleY(line.nowPoint!.r);
             const handleFocus = () => {
-              const zeroNote = `Would trend to 0% near ${tooltipDateFormatter.format(
-                new Date(line.nowPoint!.zeroHorizon)
-              )}`;
-              const combinedNotes = line.nowPoint!.notes
-                ? `${line.nowPoint!.notes} · ${zeroNote}`
-                : zeroNote;
               setTooltip({
                 x,
                 y: scaleY(Math.min(line.nowPoint!.r + 0.1, yDomain[1])),
                 topic: line.topicTitle,
                 time: line.nowPoint!.t,
                 retention: line.nowPoint!.r,
-                notes: combinedNotes
+                notes: line.nowPoint!.notes
               });
             };
             return (

--- a/src/selectors/curves.ts
+++ b/src/selectors/curves.ts
@@ -83,10 +83,22 @@ export const buildCurveSegments = (topics: Topic[]): CurveSegment[] => {
 
 export const sampleSegment = (
   segment: CurveSegment,
-  maxPoints = 160
+  maxPoints = 160,
+  nowMs: number = Date.now()
 ): { t: number; r: number }[] => {
   const startTs = new Date(segment.start.at).getTime();
-  const endTs = new Date(segment.displayEndAt).getTime();
+  if (!Number.isFinite(startTs)) {
+    return [];
+  }
+
+  const rawEndTs = new Date(segment.displayEndAt).getTime();
+  const nowLimit = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const boundedEnd = Number.isFinite(rawEndTs) ? Math.min(rawEndTs, nowLimit) : nowLimit;
+  const endTs = Math.max(startTs, boundedEnd);
+  if (endTs < startTs) {
+    return [];
+  }
+
   const durationMs = Math.max(60_000, endTs - startTs);
   const pointsCount = clamp(maxPoints, 16, 320);
   const stepMs = durationMs / pointsCount;


### PR DESCRIPTION
## Summary
- clamp timeline curve sampling to the current time and drop non-renderable segments
- recompute "now" retention only when the most recent review has occurred and remove speculative projection notes
- simplify the now-point tooltip so it no longer references predicted decay dates

## Testing
- npm run lint
- npm run test:curve *(fails: tsx not found in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e14cc3a9c48331914bc18ddedc55d6