### PR TITLE
Add fullscreen timeline view and improve timeline interactions

### DIFF
--- a/src/selectors/curves.ts
+++ b/src/selectors/curves.ts
@@ -83,10 +83,24 @@ export const buildCurveSegments = (topics: Topic[]): CurveSegment[] => {
 
 export const sampleSegment = (
   segment: CurveSegment,
-  maxPoints = 160
+  maxPoints = 160,
+  nowMs: number = Date.now()
 ): { t: number; r: number }[] => {
   const startTs = new Date(segment.start.at).getTime();
-  const endTs = new Date(segment.displayEndAt).getTime();
+  if (!Number.isFinite(startTs)) {
+    return [];
+  }
+
+  const rawEndTs = new Date(segment.displayEndAt).getTime();
+  const nowLimit = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const boundedEnd = segment.isHistorical
+    ? (Number.isFinite(rawEndTs) ? Math.min(rawEndTs, nowLimit) : nowLimit)
+    : nowLimit;
+  const endTs = Math.max(startTs, boundedEnd);
+  if (endTs < startTs) {
+    return [];
+  }
+
   const durationMs = Math.max(60_000, endTs - startTs);
   const pointsCount = clamp(maxPoints, 16, 320);
   const stepMs = durationMs / pointsCount;


### PR DESCRIPTION
## Summary
- enlarge default timeline chart heights and add fullscreen triggers for the combined and per-subject charts
- provide a fullscreen modal with focus management that reuses live timeline state so zooming, panning, and markers work edge-to-edge
- prevent the page from scrolling while zooming by capturing wheel events inside the chart container

## Testing
- npm run lint
- npm run test:curve *(fails: tsx is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e14cc3a9c48331914bc18ddedc55d6