### PR TITLE
Add timeline display toggles for fade and review markers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-scroll-area": "^1.0.6",
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-slot": "^1.0.3",
+        "@radix-ui/react-toggle": "^1.1.10",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "framer-motion": "^11.1.7",
@@ -1446,6 +1447,31 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-scroll-area": "^1.0.6",
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.3",
+    "@radix-ui/react-toggle": "^1.1.10",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "framer-motion": "^11.1.7",

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+import { cn } from "@/lib/utils";
+
+export interface ToggleProps
+  extends React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> {}
+
+export const Toggle = React.forwardRef<
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  ToggleProps
+>(({ className, ...props }, ref) => {
+  return (
+    <TogglePrimitive.Root
+      ref={ref}
+      className={cn(
+        "inline-flex items-center gap-2 rounded-xl px-3 py-2 text-xs font-medium uppercase tracking-wide transition",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
+        "data-[state=on]:bg-accent/20 data-[state=on]:text-white",
+        "data-[state=off]:text-zinc-300 data-[state=off]:hover:text-white",
+        "disabled:pointer-events-none disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  );
+});
+Toggle.displayName = "Toggle";

--- a/src/components/visualizations/timeline-panel.tsx
+++ b/src/components/visualizations/timeline-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { createPortal } from "react-dom";
 import {
   TimelineChart,
   type TimelineSeries
@@ -8,6 +9,7 @@ import {
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Toggle } from "@/components/ui/toggle";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { downloadSvg, downloadSvgAsPng } from "@/lib/export-svg";
 import { buildCurveSegments, sampleSegment } from "@/selectors/curves";
@@ -18,6 +20,8 @@ import { SubjectFilterValue, NO_SUBJECT_KEY } from "@/components/dashboard/topic
 import {
   CalendarClock,
   Check,
+  Droplet,
+  EllipsisVertical,
   Eye,
   EyeOff,
   Filter,
@@ -31,7 +35,9 @@ import {
   RotateCcw,
   Undo2,
   Hand,
-  SquareDashedMousePointer
+  SquareDashedMousePointer,
+  Maximize2,
+  Minimize2
 } from "lucide-react";
 import {
   daysBetween,
@@ -51,8 +57,6 @@ const MIN_ZOOM_SPAN = DAY_MS;
 const MIN_Y_SPAN = 0.05;
 const KEYBOARD_STEP_MS = DAY_MS;
 const DEFAULT_SUBJECT_ID = "subject-general";
-const RETENTION_PROJECTION_DAYS = 30;
-
 type TopicVisibility = Record<string, boolean>;
 type SortView = "next" | "title";
 type TimelineViewMode = "combined" | "per-subject";
@@ -64,6 +68,10 @@ type SubjectSeriesGroup = {
   color: string;
   series: TimelineSeries[];
 };
+
+type FullscreenTarget =
+  | { type: "combined" }
+  | { type: "subject"; subjectId: string };
 
 const ensureVisibilityState = (topics: Topic[], prev: TopicVisibility): TopicVisibility => {
   const next: TopicVisibility = { ...prev };
@@ -126,22 +134,31 @@ const deriveSeries = (
       nowPoint: null
     };
 
-    let previousSegment: (typeof topicSegments)[number] | null = null;
+    let previousRenderableSegment: (typeof topicSegments)[number] | null = null;
 
     for (const segment of topicSegments) {
-      const samples = sampleSegment(segment, 160);
-      pack.points.push(...samples);
-      const checkpointTime = new Date(segment.checkpointAt).getTime();
-      pack.segments.push({
-        id: `${segment.topicId}-${segment.start.id}-${segment.displayEndAt}`,
-        points: samples,
-        isHistorical: segment.isHistorical,
-        checkpoint: includeCheckpoints && Number.isFinite(checkpointTime)
-          ? { t: checkpointTime, target: segment.target }
-          : undefined
-      });
-
+      const samples = sampleSegment(segment, 160, nowMs);
+      const hasSamples = samples.length > 0;
       const reviewTime = new Date(segment.start.at).getTime();
+      if (hasSamples) {
+        pack.points.push(...samples);
+      }
+      const checkpointTime = new Date(segment.checkpointAt).getTime();
+      if (hasSamples) {
+        const fadeFrom = Number.isFinite(reviewTime)
+          ? reviewTime
+          : samples[0]?.t ?? nowMs;
+        pack.segments.push({
+          id: `${segment.topicId}-${segment.start.id}-${segment.displayEndAt}`,
+          points: samples,
+          isHistorical: segment.isHistorical,
+          fade: { from: fadeFrom, to: nowMs },
+          checkpoint: includeCheckpoints && Number.isFinite(checkpointTime)
+            ? { t: checkpointTime, target: segment.target }
+            : undefined
+        });
+      }
+
       if (Number.isFinite(reviewTime) && !pack.events.some((event) => event.id === segment.start.id)) {
         const notes: string[] = [];
         if (typeof segment.start.reviewQuality === "number") {
@@ -155,13 +172,6 @@ const deriveSeries = (
             `Retention ${(segment.start.retrievabilityAtReview * 100).toFixed(0)}% at review`
           );
         }
-        const projectionRetention = computeRetrievability(
-          segment.stabilityDays,
-          RETENTION_PROJECTION_DAYS * DAY_MS
-        );
-        notes.push(
-          `Predicted retention in ${RETENTION_PROJECTION_DAYS}d ≈ ${(projectionRetention * 100).toFixed(0)}%`
-        );
         pack.events.push({
           id: segment.start.id,
           t: reviewTime,
@@ -190,10 +200,10 @@ const deriveSeries = (
         }
       }
 
-      if (previousSegment && Number.isFinite(reviewTime)) {
-        const prevStart = new Date(previousSegment.start.at).getTime();
+      if (previousRenderableSegment && hasSamples && Number.isFinite(reviewTime)) {
+        const prevStart = new Date(previousRenderableSegment.start.at).getTime();
         const elapsed = Math.max(0, reviewTime - prevStart);
-        const priorRetention = computeRetrievability(previousSegment.stabilityDays, elapsed);
+        const priorRetention = computeRetrievability(previousRenderableSegment.stabilityDays, elapsed);
         pack.stitches.push({
           id: `stitch-${segment.start.id}`,
           t: reviewTime,
@@ -206,23 +216,25 @@ const deriveSeries = (
         });
       }
 
-      previousSegment = segment;
+      if (hasSamples) {
+        previousRenderableSegment = segment;
+      }
     }
 
     const activeSegment = topicSegments[topicSegments.length - 1];
     if (activeSegment) {
       const startTime = new Date(activeSegment.start.at).getTime();
-      if (Number.isFinite(startTime)) {
+      if (Number.isFinite(startTime) && startTime <= nowMs) {
         const elapsed = Math.max(0, nowMs - startTime);
         const stability = Math.max(activeSegment.stabilityDays, STABILITY_MIN_DAYS);
         const retentionNow = computeRetrievability(stability, elapsed);
-        const zeroHorizon = startTime + Math.max(0, Math.round(stability * Math.log(100) * DAY_MS));
         pack.nowPoint = {
           t: nowMs,
           r: retentionNow,
-          zeroHorizon,
           notes: `Stability ≈ ${stability.toFixed(2)} days`
         };
+      } else {
+        pack.nowPoint = null;
       }
     }
 
@@ -428,11 +440,15 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
   const [hasStudyActivity, setHasStudyActivity] = React.useState(true);
   const [showExamMarkers, setShowExamMarkers] = React.useState(true);
   const [showCheckpoints, setShowCheckpoints] = React.useState(false);
+  const [showOpacityFade, setShowOpacityFade] = React.useState(true);
+  const [showReviewMarkers, setShowReviewMarkers] = React.useState(false);
   const svgRef = React.useRef<SVGSVGElement | null>(null);
   const perSubjectSvgRefs = React.useRef(new Map<string, SVGSVGElement | null>());
   const perSubjectContainerRef = React.useRef<HTMLDivElement | null>(null);
   const pointerInstructionId = React.useId();
   const spacePressedRef = React.useRef(false);
+  const [fullscreenTarget, setFullscreenTarget] = React.useState<FullscreenTarget | null>(null);
+  const fullscreenReturnFocusRef = React.useRef<HTMLElement | null>(null);
   const setSubjectChartRef = React.useCallback((subjectId: string, element: SVGSVGElement | null) => {
     const map = perSubjectSvgRefs.current;
     if (element) {
@@ -635,6 +651,10 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
     toast.error("Select at least one full day to zoom.");
   }, []);
 
+  const handleCloseFullscreen = React.useCallback(() => {
+    setFullscreenTarget(null);
+  }, []);
+
   React.useEffect(() => {
     const handleKeydown = (event: KeyboardEvent) => {
       const target = event.target as HTMLElement | null;
@@ -807,6 +827,20 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
   }, [filteredTopics, subjectLookup, visibility, resolveTopicColor, nowMs, showCheckpoints]);
 
   React.useEffect(() => {
+    if (!fullscreenTarget) return;
+    if (!domain || !yDomain) {
+      setFullscreenTarget(null);
+      return;
+    }
+    if (fullscreenTarget.type === "subject") {
+      const exists = perSubjectSeries.some((group) => group.subjectId === fullscreenTarget.subjectId);
+      if (!exists) {
+        setFullscreenTarget(null);
+      }
+    }
+  }, [fullscreenTarget, domain, yDomain, perSubjectSeries]);
+
+  React.useEffect(() => {
     if (series.length === 0) {
       const fallback: [number, number] = [0, 1];
       setFullYDomain(fallback);
@@ -910,6 +944,100 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
       .slice(0, variant === "compact" ? 5 : 8);
   }, [filteredTopics, variant]);
 
+  const fullscreenConfig = React.useMemo(() => {
+    if (!fullscreenTarget) return null;
+    if (!domain || !yDomain) return null;
+
+    if (fullscreenTarget.type === "combined") {
+      if (series.length === 0) return null;
+      const markers = showExamMarkers ? examMarkers : [];
+      return {
+        title: "Review timeline",
+        subtitle: "Fullscreen view",
+        renderChart: (height: number) => (
+          <TimelineChart
+            series={series}
+            xDomain={domain}
+            yDomain={yDomain}
+            onViewportChange={(next, options) => handleViewportChange(next, { push: options?.push })}
+            height={height}
+            showGrid
+            fullDomain={fullDomain ?? undefined}
+            fullYDomain={fullYDomain ?? undefined}
+            examMarkers={markers}
+            timeZone={resolvedTimezone}
+            onResetDomain={handleResetDomain}
+            ariaDescribedBy={`timeline-zoom-shortcuts ${pointerInstructionId}`}
+            interactionMode={interactionMode}
+            temporaryPan={spacePanning}
+            onRequestStepBack={handleStepBack}
+            onTooSmallSelection={handleTooSmallSelection}
+            keyboardSelection={keyboardSelection}
+            showOpacityFade={showOpacityFade}
+            showReviewLines={showReviewMarkers}
+          />
+        )
+      } as const;
+    }
+
+    const group = perSubjectSeries.find((item) => item.subjectId === fullscreenTarget.subjectId);
+    if (!group || group.series.length === 0) return null;
+    const markers = showExamMarkers ? examMarkersBySubject.get(group.subjectId) ?? [] : [];
+    const subtitle = group.subject?.examDate ? `Exam ${formatDateWithWeekday(group.subject.examDate)}` : undefined;
+
+    return {
+      title: `${group.label} timeline`,
+      subtitle,
+      renderChart: (height: number) => (
+        <TimelineChart
+          series={group.series}
+          xDomain={domain}
+          yDomain={yDomain}
+          onViewportChange={(next, options) => handleViewportChange(next, { push: options?.push })}
+          height={height}
+          showGrid
+          fullDomain={fullDomain ?? undefined}
+          fullYDomain={fullYDomain ?? undefined}
+          examMarkers={markers}
+          timeZone={resolvedTimezone}
+          onResetDomain={handleResetDomain}
+          ariaDescribedBy={`timeline-zoom-shortcuts ${pointerInstructionId}`}
+          interactionMode={interactionMode}
+          temporaryPan={spacePanning}
+          onRequestStepBack={handleStepBack}
+          onTooSmallSelection={handleTooSmallSelection}
+          keyboardSelection={keyboardSelection}
+          showOpacityFade={showOpacityFade}
+          showReviewLines={showReviewMarkers}
+        />
+      )
+    } as const;
+  }, [
+    fullscreenTarget,
+    domain,
+    yDomain,
+    series,
+    showExamMarkers,
+    examMarkers,
+    handleViewportChange,
+    fullDomain,
+    fullYDomain,
+    resolvedTimezone,
+    handleResetDomain,
+    pointerInstructionId,
+    interactionMode,
+    spacePanning,
+    handleStepBack,
+    handleTooSmallSelection,
+    keyboardSelection,
+    perSubjectSeries,
+    examMarkersBySubject,
+    showOpacityFade,
+    showReviewMarkers
+  ]);
+
+  const isFullscreenOpen = Boolean(fullscreenConfig);
+
   const buildPerSubjectExportSvg = React.useCallback(() => {
     const container = perSubjectContainerRef.current;
     if (!container) return null;
@@ -1000,8 +1128,9 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
     : "rounded-3xl border border-white/5 bg-slate-900/40 p-6 md:p-8 shadow-xl shadow-slate-900/30";
 
   return (
-    <section className={`${cardClasses} space-y-5`}
-      aria-label="Review timeline">
+    <>
+      <section className={`${cardClasses} space-y-5`}
+        aria-label="Review timeline">
       <header className="flex flex-wrap items-center gap-3">
         <div>
           <div className="inline-flex items-center gap-2 rounded-full bg-accent/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-accent">
@@ -1115,6 +1244,32 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
               Pan (Space)
             </Button>
           </div>
+          <div
+            className="flex items-center gap-1 rounded-2xl border border-white/10 bg-slate-900/60 p-1"
+            role="group"
+            aria-label="Timeline display options"
+          >
+            <Toggle
+              type="button"
+              pressed={showOpacityFade}
+              onPressedChange={(pressed) => setShowOpacityFade(Boolean(pressed))}
+              aria-label="Toggle opacity fade"
+              title="Toggle opacity fade"
+            >
+              <Droplet className="h-3.5 w-3.5" />
+              <span>Opacity fade</span>
+            </Toggle>
+            <Toggle
+              type="button"
+              pressed={showReviewMarkers}
+              onPressedChange={(pressed) => setShowReviewMarkers(Boolean(pressed))}
+              aria-label="Toggle review markers"
+              title="Toggle review markers"
+            >
+              <EllipsisVertical className="h-3.5 w-3.5" />
+              <span>Review markers</span>
+            </Toggle>
+          </div>
           <Button
             size="sm"
             variant="outline"
@@ -1124,6 +1279,21 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
           >
             <RotateCcw className="h-4 w-4" />
             <span>Reset</span>
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={(event) => {
+              fullscreenReturnFocusRef.current = event.currentTarget;
+              setFullscreenTarget({ type: "combined" });
+            }}
+            disabled={!domain || !yDomain || series.length === 0}
+            className="inline-flex items-center gap-2"
+            aria-label="Expand timeline to fullscreen"
+            title="Expand timeline"
+          >
+            <Maximize2 className="h-4 w-4" />
+            <span>Fullscreen</span>
           </Button>
           {variant === "default" ? (
             <>
@@ -1286,7 +1456,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                 xDomain={domain}
                 yDomain={yDomain}
                 onViewportChange={(next, options) => handleViewportChange(next, { push: options?.push })}
-                height={variant === "compact" ? 260 : 360}
+                height={variant === "compact" ? 320 : 460}
                 showGrid
                 fullDomain={fullDomain ?? undefined}
                 fullYDomain={fullYDomain ?? undefined}
@@ -1299,6 +1469,8 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                 onRequestStepBack={handleStepBack}
                 onTooSmallSelection={handleTooSmallSelection}
                 keyboardSelection={keyboardSelection}
+                showOpacityFade={showOpacityFade}
+                showReviewLines={showReviewMarkers}
               />
             )
           : (
@@ -1333,9 +1505,25 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                           />
                           <h3 className="text-sm font-semibold text-white">{group.label}</h3>
                         </div>
-                        {examLabel ? (
-                          <span className="text-xs text-zinc-400">Exam {examLabel}</span>
-                        ) : null}
+                        <div className="flex items-center gap-2">
+                          {examLabel ? (
+                            <span className="text-xs text-zinc-400">Exam {examLabel}</span>
+                          ) : null}
+                          <Button
+                            type="button"
+                            size="icon"
+                            variant="ghost"
+                            onClick={(event) => {
+                              fullscreenReturnFocusRef.current = event.currentTarget;
+                              setFullscreenTarget({ type: "subject", subjectId: group.subjectId });
+                            }}
+                            disabled={!domain || !yDomain || group.series.length === 0}
+                            aria-label={`Expand ${group.label} timeline`}
+                            title="Expand timeline"
+                          >
+                            <Maximize2 className="h-4 w-4" />
+                          </Button>
+                        </div>
                       </div>
                       <TimelineChart
                         ref={(element) => setSubjectChartRef(group.subjectId, element)}
@@ -1343,7 +1531,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                         xDomain={domain}
                         yDomain={yDomain}
                         onViewportChange={(next, options) => handleViewportChange(next, { push: options?.push })}
-                        height={variant === "compact" ? 240 : 300}
+                        height={variant === "compact" ? 300 : 360}
                         showGrid
                         fullDomain={fullDomain ?? undefined}
                         fullYDomain={fullYDomain ?? undefined}
@@ -1356,6 +1544,8 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                         onRequestStepBack={handleStepBack}
                         onTooSmallSelection={handleTooSmallSelection}
                         keyboardSelection={keyboardSelection}
+                        showOpacityFade={showOpacityFade}
+                        showReviewLines={showReviewMarkers}
                       />
                     </div>
                   );
@@ -1450,6 +1640,212 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
           )}
         </div>
       </div>
-    </section>
+      </section>
+      <TimelineFullscreenDialog
+        open={isFullscreenOpen}
+        title={fullscreenConfig?.title ?? ""}
+        subtitle={fullscreenConfig?.subtitle}
+        onClose={handleCloseFullscreen}
+        renderChart={fullscreenConfig?.renderChart}
+        returnFocusRef={fullscreenReturnFocusRef}
+      />
+    </>
   );
+}
+
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+interface TimelineFullscreenDialogProps {
+  open: boolean;
+  title: string;
+  subtitle?: string;
+  onClose: () => void;
+  renderChart?: ((height: number) => React.ReactNode) | null;
+  returnFocusRef?: React.RefObject<HTMLElement | null>;
+}
+
+function TimelineFullscreenDialog({
+  open,
+  title,
+  subtitle,
+  onClose,
+  renderChart,
+  returnFocusRef
+}: TimelineFullscreenDialogProps) {
+  const [isMounted, setIsMounted] = React.useState(false);
+  const dialogRef = React.useRef<HTMLDivElement | null>(null);
+  const overlayRef = React.useRef<HTMLDivElement | null>(null);
+  const previouslyFocused = React.useRef<HTMLElement | null>(null);
+  const [viewportHeight, setViewportHeight] = React.useState(() =>
+    typeof window === "undefined" ? 900 : window.innerHeight
+  );
+  const titleId = React.useId();
+  const descriptionId = React.useId();
+
+  React.useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const updateHeight = () => setViewportHeight(window.innerHeight);
+    updateHeight();
+    window.addEventListener("resize", updateHeight);
+    window.addEventListener("orientationchange", updateHeight);
+    return () => {
+      window.removeEventListener("resize", updateHeight);
+      window.removeEventListener("orientationchange", updateHeight);
+    };
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    previouslyFocused.current = document.activeElement as HTMLElement | null;
+
+    const body = document.body;
+    const previousOverflow = body.style.overflow;
+    const previousPaddingRight = body.style.paddingRight;
+    const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+
+    body.style.overflow = "hidden";
+    if (scrollbarWidth > 0) {
+      body.style.paddingRight = `${scrollbarWidth}px`;
+    }
+
+    const focusDialog = () => {
+      const node = dialogRef.current;
+      if (!node) return;
+      const focusable = Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((element) => !element.hasAttribute("disabled"));
+      const target = focusable[0] ?? node;
+      window.requestAnimationFrame(() => target.focus({ preventScroll: true }));
+    };
+
+    focusDialog();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab") return;
+
+      const node = dialogRef.current;
+      if (!node) return;
+
+      const focusable = Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((element) => !element.hasAttribute("disabled"));
+
+      if (focusable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+
+      if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first.focus({ preventScroll: true });
+      } else if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last.focus({ preventScroll: true });
+      }
+    };
+
+    const handleFocusIn = (event: FocusEvent) => {
+      const node = dialogRef.current;
+      if (!node) return;
+      if (node.contains(event.target as Node)) return;
+      const focusable = Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((element) => !element.hasAttribute("disabled"));
+      const fallback = focusable[0] ?? node;
+      window.requestAnimationFrame(() => fallback.focus({ preventScroll: true }));
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("focusin", handleFocusIn);
+
+    return () => {
+      body.style.overflow = previousOverflow;
+      body.style.paddingRight = previousPaddingRight;
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("focusin", handleFocusIn);
+    };
+  }, [open, onClose]);
+
+  React.useEffect(() => {
+    if (open) return;
+    const target = returnFocusRef?.current ?? previouslyFocused.current;
+    if (target && target.isConnected) {
+      window.requestAnimationFrame(() => target.focus({ preventScroll: true }));
+    }
+  }, [open, returnFocusRef]);
+
+  if (!isMounted || !open || !renderChart) {
+    return null;
+  }
+
+  const chartHeight = Math.max(viewportHeight - 160, 520);
+
+  const overlay = (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-[1200] flex flex-col bg-slate-950/95 backdrop-blur"
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === overlayRef.current) {
+          onClose();
+        }
+      }}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        className="flex h-full w-full flex-col gap-6 p-4 text-white sm:p-6"
+      >
+        <header className="flex flex-wrap items-center justify-between gap-4">
+          <div className="space-y-1">
+            <h2 id={titleId} className="text-xl font-semibold text-white">
+              {title}
+            </h2>
+            <p id={descriptionId} className="text-sm text-zinc-300">
+              {subtitle ?? "Interact with the expanded retention timeline."}
+            </p>
+          </div>
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            onClick={onClose}
+            aria-label="Exit fullscreen"
+          >
+            <Minimize2 className="h-5 w-5" />
+          </Button>
+        </header>
+        <div className="flex min-h-0 flex-1 flex-col gap-4">
+          <div className="flex min-h-0 flex-1 items-stretch rounded-3xl border border-white/10 bg-slate-900/60 p-3">
+            <div className="h-full w-full">{renderChart(chartHeight)}</div>
+          </div>
+          <p className="text-xs text-zinc-400">
+            Use the mouse wheel or touch gestures to zoom, drag to pan, or press Escape to exit fullscreen.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(overlay, document.body);
 }

--- a/src/selectors/curves.ts
+++ b/src/selectors/curves.ts
@@ -83,25 +83,49 @@ export const buildCurveSegments = (topics: Topic[]): CurveSegment[] => {
 
 export const sampleSegment = (
   segment: CurveSegment,
-  maxPoints = 160
-): { t: number; r: number }[] => {
+  maxPoints = 160,
+  nowMs: number = Date.now()
+): { t: number; r: number; opacity: number }[] => {
   const startTs = new Date(segment.start.at).getTime();
-  const endTs = new Date(segment.displayEndAt).getTime();
+  if (!Number.isFinite(startTs)) {
+    return [];
+  }
+
+  const rawEndTs = new Date(segment.displayEndAt).getTime();
+  const nowLimit = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const boundedEnd = segment.isHistorical
+    ? (Number.isFinite(rawEndTs) ? Math.min(rawEndTs, nowLimit) : nowLimit)
+    : nowLimit;
+  const endTs = Math.max(startTs, boundedEnd);
+  if (endTs < startTs) {
+    return [];
+  }
+
   const durationMs = Math.max(60_000, endTs - startTs);
   const pointsCount = clamp(maxPoints, 16, 320);
   const stepMs = durationMs / pointsCount;
   const stability = Math.max(segment.stabilityDays, STABILITY_MIN_DAYS);
-  const points: { t: number; r: number }[] = [];
+  const points: { t: number; r: number; opacity: number }[] = [];
+
+  const nowSpan = nowLimit - startTs;
+  const computeOpacity = (timestamp: number) => {
+    if (!Number.isFinite(timestamp)) return 0;
+    if (nowSpan <= 0) {
+      return timestamp >= startTs ? 1 : 0;
+    }
+    const ratio = (timestamp - startTs) / nowSpan;
+    return clamp(ratio, 0, 1);
+  };
 
   for (let ts = startTs; ts <= endTs; ts += stepMs) {
     const elapsedMs = ts - startTs;
     const retention = computeRetrievability(stability, elapsedMs);
-    points.push({ t: ts, r: clamp(retention, 0, 1) });
+    points.push({ t: ts, r: clamp(retention, 0, 1), opacity: computeOpacity(ts) });
   }
 
   if (!points.some((point) => point.t === endTs)) {
     const retention = computeRetrievability(stability, endTs - startTs);
-    points.push({ t: endTs, r: clamp(retention, 0, 1) });
+    points.push({ t: endTs, r: clamp(retention, 0, 1), opacity: computeOpacity(endTs) });
   }
 
   return points;


### PR DESCRIPTION
## Summary
- add toolbar toggles so users can control opacity fading and review marker visibility across combined, per-subject, and fullscreen timelines
- teach TimelineChart to switch gradients and stitched review lines on or off according to the new toggle props
- introduce a reusable Toggle component backed by @radix-ui/react-toggle for consistent styling

## Testing
- npm run lint
- npm run test:curve

------
https://chatgpt.com/codex/tasks/task_b_68e14cc3a9c48331914bc18ddedc55d6