### PR TITLE
Add toolbar toggles for timeline review markers and opacity fade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1016,7 +1016,7 @@
       "version": "1.55.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
       "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.55.1"
@@ -1731,14 +1731,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.25",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.25.tgz",
       "integrity": "sha512-oSVZmGtDPmRZtVDqvdKUi/qgCsWp5IDY29wp8na8Bj4B3cc99hfNzvNhlMkVVxctkAOGUA3Km7MMpBHAnWfcIA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1749,7 +1749,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -3036,7 +3036,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5841,7 +5841,7 @@
       "version": "1.55.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
       "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.55.1"
@@ -5860,7 +5860,7 @@
       "version": "1.55.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
       "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -15,10 +15,10 @@ export const Toggle = React.forwardRef<
     <TogglePrimitive.Root
       ref={ref}
       className={cn(
-        "inline-flex items-center gap-2 rounded-xl px-3 py-2 text-xs font-medium uppercase tracking-wide transition",
+        "inline-flex items-center gap-2 rounded-xl border border-white/10 bg-slate-950/30 px-3 py-2 text-xs font-medium uppercase tracking-wide transition",
         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
-        "data-[state=on]:bg-accent/20 data-[state=on]:text-white",
-        "data-[state=off]:text-zinc-300 data-[state=off]:hover:text-white",
+        "data-[state=on]:border-accent/40 data-[state=on]:bg-accent/25 data-[state=on]:text-white",
+        "data-[state=off]:text-zinc-300 data-[state=off]:hover:border-white/20 data-[state=off]:hover:bg-slate-900/60 data-[state=off]:hover:text-white",
         "disabled:pointer-events-none disabled:opacity-50",
         className
       )}

--- a/src/components/visualizations/timeline-chart.tsx
+++ b/src/components/visualizations/timeline-chart.tsx
@@ -918,10 +918,8 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
             );
           })
           : null}
-        {line.events.map((event) => {
-          if (!showReviewMarkers && event.type === "reviewed") {
-            return null;
-          }
+        {showReviewMarkers
+          ? line.events.map((event) => {
           const x = scaleX(event.t);
           let yValue = 1;
           if (event.type === "checkpoint") {
@@ -1009,7 +1007,8 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
               onMouseLeave={hideTooltip}
             />
           );
-        })}
+          })
+          : null}
         {line.nowPoint && line.nowPoint.t >= xDomain[0] && line.nowPoint.t <= xDomain[1] ? (
           (() => {
             const x = scaleX(line.nowPoint!.t);

--- a/src/components/visualizations/timeline-chart.tsx
+++ b/src/components/visualizations/timeline-chart.tsx
@@ -125,7 +125,7 @@ interface TimelineChartProps {
   onTooSmallSelection?: () => void;
   keyboardSelection?: KeyboardBand | null;
   showOpacityFade?: boolean;
-  showReviewLines?: boolean;
+  showReviewMarkers?: boolean;
 }
 
 const PADDING_X = 48;
@@ -189,7 +189,7 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
       onTooSmallSelection,
       keyboardSelection,
       showOpacityFade = true,
-      showReviewLines = false
+      showReviewMarkers = false
     },
     ref
   ) => {
@@ -897,7 +897,7 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
             />
           );
         })}
-        {showReviewLines
+        {showReviewMarkers
           ? line.stitches.map((stitch) => {
             const x = scaleX(stitch.t);
             const yTop = scaleY(Math.min(1, Math.max(yDomain[0], stitch.to)));
@@ -919,6 +919,9 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
           })
           : null}
         {line.events.map((event) => {
+          if (!showReviewMarkers && event.type === "reviewed") {
+            return null;
+          }
           const x = scaleX(event.t);
           let yValue = 1;
           if (event.type === "checkpoint") {

--- a/src/components/visualizations/timeline-panel.tsx
+++ b/src/components/visualizations/timeline-panel.tsx
@@ -15,6 +15,7 @@ import { downloadSvg, downloadSvgAsPng } from "@/lib/export-svg";
 import { buildCurveSegments, sampleSegment } from "@/selectors/curves";
 import { useTopicStore } from "@/stores/topics";
 import { useProfileStore } from "@/stores/profile";
+import { useTimelinePreferencesStore } from "@/stores/timeline-preferences";
 import { Subject, Topic } from "@/types/topic";
 import { SubjectFilterValue, NO_SUBJECT_KEY } from "@/components/dashboard/topic-list";
 import {
@@ -440,8 +441,10 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
   const [hasStudyActivity, setHasStudyActivity] = React.useState(true);
   const [showExamMarkers, setShowExamMarkers] = React.useState(true);
   const [showCheckpoints, setShowCheckpoints] = React.useState(false);
-  const [showOpacityFade, setShowOpacityFade] = React.useState(true);
-  const [showReviewMarkers, setShowReviewMarkers] = React.useState(false);
+  const showOpacityFade = useTimelinePreferencesStore((state) => state.showOpacityFade);
+  const setShowOpacityFade = useTimelinePreferencesStore((state) => state.setShowOpacityFade);
+  const showReviewMarkers = useTimelinePreferencesStore((state) => state.showReviewMarkers);
+  const setShowReviewMarkers = useTimelinePreferencesStore((state) => state.setShowReviewMarkers);
   const svgRef = React.useRef<SVGSVGElement | null>(null);
   const perSubjectSvgRefs = React.useRef(new Map<string, SVGSVGElement | null>());
   const perSubjectContainerRef = React.useRef<HTMLDivElement | null>(null);
@@ -974,7 +977,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
             onTooSmallSelection={handleTooSmallSelection}
             keyboardSelection={keyboardSelection}
             showOpacityFade={showOpacityFade}
-            showReviewLines={showReviewMarkers}
+            showReviewMarkers={showReviewMarkers}
           />
         )
       } as const;
@@ -1008,7 +1011,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
           onTooSmallSelection={handleTooSmallSelection}
           keyboardSelection={keyboardSelection}
           showOpacityFade={showOpacityFade}
-          showReviewLines={showReviewMarkers}
+          showReviewMarkers={showReviewMarkers}
         />
       )
     } as const;
@@ -1257,7 +1260,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
               title="Toggle opacity fade"
             >
               <Droplet className="h-3.5 w-3.5" />
-              <span>Opacity fade</span>
+              <span>Opacity Fade</span>
             </Toggle>
             <Toggle
               type="button"
@@ -1267,7 +1270,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
               title="Toggle review markers"
             >
               <EllipsisVertical className="h-3.5 w-3.5" />
-              <span>Review markers</span>
+              <span>Review Markers</span>
             </Toggle>
           </div>
           <Button
@@ -1470,7 +1473,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                 onTooSmallSelection={handleTooSmallSelection}
                 keyboardSelection={keyboardSelection}
                 showOpacityFade={showOpacityFade}
-                showReviewLines={showReviewMarkers}
+                showReviewMarkers={showReviewMarkers}
               />
             )
           : (
@@ -1545,7 +1548,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                         onTooSmallSelection={handleTooSmallSelection}
                         keyboardSelection={keyboardSelection}
                         showOpacityFade={showOpacityFade}
-                        showReviewLines={showReviewMarkers}
+                        showReviewMarkers={showReviewMarkers}
                       />
                     </div>
                   );

--- a/src/components/visualizations/timeline-panel.tsx
+++ b/src/components/visualizations/timeline-panel.tsx
@@ -22,6 +22,7 @@ import {
   CalendarClock,
   Check,
   Droplet,
+  Dot,
   EllipsisVertical,
   Eye,
   EyeOff,
@@ -441,10 +442,12 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
   const [hasStudyActivity, setHasStudyActivity] = React.useState(true);
   const [showExamMarkers, setShowExamMarkers] = React.useState(true);
   const [showCheckpoints, setShowCheckpoints] = React.useState(false);
-  const showOpacityFade = useTimelinePreferencesStore((state) => state.showOpacityFade);
-  const setShowOpacityFade = useTimelinePreferencesStore((state) => state.setShowOpacityFade);
+  const showOpacityGradient = useTimelinePreferencesStore((state) => state.showOpacityGradient);
+  const setShowOpacityGradient = useTimelinePreferencesStore((state) => state.setShowOpacityGradient);
   const showReviewMarkers = useTimelinePreferencesStore((state) => state.showReviewMarkers);
   const setShowReviewMarkers = useTimelinePreferencesStore((state) => state.setShowReviewMarkers);
+  const showEventDots = useTimelinePreferencesStore((state) => state.showEventDots);
+  const setShowEventDots = useTimelinePreferencesStore((state) => state.setShowEventDots);
   const svgRef = React.useRef<SVGSVGElement | null>(null);
   const perSubjectSvgRefs = React.useRef(new Map<string, SVGSVGElement | null>());
   const perSubjectContainerRef = React.useRef<HTMLDivElement | null>(null);
@@ -976,8 +979,9 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
             onRequestStepBack={handleStepBack}
             onTooSmallSelection={handleTooSmallSelection}
             keyboardSelection={keyboardSelection}
-            showOpacityFade={showOpacityFade}
+            showOpacityGradient={showOpacityGradient}
             showReviewMarkers={showReviewMarkers}
+            showEventDots={showEventDots}
           />
         )
       } as const;
@@ -1010,8 +1014,9 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
           onRequestStepBack={handleStepBack}
           onTooSmallSelection={handleTooSmallSelection}
           keyboardSelection={keyboardSelection}
-          showOpacityFade={showOpacityFade}
+          showOpacityGradient={showOpacityGradient}
           showReviewMarkers={showReviewMarkers}
+          showEventDots={showEventDots}
         />
       )
     } as const;
@@ -1035,8 +1040,9 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
     keyboardSelection,
     perSubjectSeries,
     examMarkersBySubject,
-    showOpacityFade,
-    showReviewMarkers
+    showOpacityGradient,
+    showReviewMarkers,
+    showEventDots
   ]);
 
   const isFullscreenOpen = Boolean(fullscreenConfig);
@@ -1247,32 +1253,6 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
               Pan (Space)
             </Button>
           </div>
-          <div
-            className="flex items-center gap-1 rounded-2xl border border-white/10 bg-slate-900/60 p-1"
-            role="group"
-            aria-label="Timeline display options"
-          >
-            <Toggle
-              type="button"
-              pressed={showOpacityFade}
-              onPressedChange={(pressed) => setShowOpacityFade(Boolean(pressed))}
-              aria-label="Toggle opacity fade"
-              title="Toggle opacity fade"
-            >
-              <Droplet className="h-3.5 w-3.5" />
-              <span>Opacity Fade</span>
-            </Toggle>
-            <Toggle
-              type="button"
-              pressed={showReviewMarkers}
-              onPressedChange={(pressed) => setShowReviewMarkers(Boolean(pressed))}
-              aria-label="Toggle review markers"
-              title="Toggle review markers"
-            >
-              <EllipsisVertical className="h-3.5 w-3.5" />
-              <span>Review Markers</span>
-            </Toggle>
-          </div>
           <Button
             size="sm"
             variant="outline"
@@ -1384,28 +1364,62 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
             <SelectItem value="title">Topic name</SelectItem>
           </SelectContent>
         </Select>
-        <button
-          type="button"
-          onClick={() => setShowExamMarkers((prev) => !prev)}
-          className={`inline-flex items-center gap-2 rounded-2xl border px-3 py-2 text-xs transition ${
-            showExamMarkers
-              ? "border-accent/40 bg-accent/20 text-white"
-              : "border-white/10 bg-transparent text-zinc-400 hover:text-white"
-          }`}
+        <div
+          className="flex flex-wrap items-center gap-1 rounded-2xl border border-white/10 bg-slate-900/60 p-1"
+          role="group"
+          aria-label="Timeline overlays"
         >
-          <CalendarClock className="h-3.5 w-3.5" /> Exam markers {showExamMarkers ? "on" : "off"}
-        </button>
-        <button
-          type="button"
-          onClick={() => setShowCheckpoints((prev) => !prev)}
-          className={`inline-flex items-center gap-2 rounded-2xl border px-3 py-2 text-xs transition ${
-            showCheckpoints
-              ? "border-accent/40 bg-accent/20 text-white"
-              : "border-white/10 bg-transparent text-zinc-400 hover:text-white"
-          }`}
-        >
-          <Milestone className="h-3.5 w-3.5" /> Checkpoints {showCheckpoints ? "on" : "off"}
-        </button>
+          <Toggle
+            type="button"
+            pressed={showExamMarkers}
+            onPressedChange={(pressed) => setShowExamMarkers(Boolean(pressed))}
+            aria-label="Toggle exam markers"
+            title="Toggle exam markers"
+          >
+            <CalendarClock className="h-3.5 w-3.5" />
+            <span>Exam Markers</span>
+          </Toggle>
+          <Toggle
+            type="button"
+            pressed={showCheckpoints}
+            onPressedChange={(pressed) => setShowCheckpoints(Boolean(pressed))}
+            aria-label="Toggle checkpoints"
+            title="Toggle checkpoints"
+          >
+            <Milestone className="h-3.5 w-3.5" />
+            <span>Checkpoints</span>
+          </Toggle>
+          <Toggle
+            type="button"
+            pressed={showReviewMarkers}
+            onPressedChange={(pressed) => setShowReviewMarkers(Boolean(pressed))}
+            aria-label="Toggle review markers"
+            title="Toggle review markers"
+          >
+            <EllipsisVertical className="h-3.5 w-3.5" />
+            <span>Review Markers</span>
+          </Toggle>
+          <Toggle
+            type="button"
+            pressed={showEventDots}
+            onPressedChange={(pressed) => setShowEventDots(Boolean(pressed))}
+            aria-label="Toggle event start dots"
+            title="Toggle event start dots"
+          >
+            <Dot className="h-3.5 w-3.5" />
+            <span>Event Dots</span>
+          </Toggle>
+          <Toggle
+            type="button"
+            pressed={showOpacityGradient}
+            onPressedChange={(pressed) => setShowOpacityGradient(Boolean(pressed))}
+            aria-label="Toggle opacity gradient"
+            title="Toggle opacity gradient"
+          >
+            <Droplet className="h-3.5 w-3.5" />
+            <span>Opacity Gradient</span>
+          </Toggle>
+        </div>
         {categoryFilter.size > 0 ? (
           <Button size="sm" variant="ghost" onClick={() => setCategoryFilter(new Set())}>
             Clear categories
@@ -1472,8 +1486,9 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                 onRequestStepBack={handleStepBack}
                 onTooSmallSelection={handleTooSmallSelection}
                 keyboardSelection={keyboardSelection}
-                showOpacityFade={showOpacityFade}
+                showOpacityGradient={showOpacityGradient}
                 showReviewMarkers={showReviewMarkers}
+                showEventDots={showEventDots}
               />
             )
           : (
@@ -1547,8 +1562,9 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                         onRequestStepBack={handleStepBack}
                         onTooSmallSelection={handleTooSmallSelection}
                         keyboardSelection={keyboardSelection}
-                        showOpacityFade={showOpacityFade}
+                        showOpacityGradient={showOpacityGradient}
                         showReviewMarkers={showReviewMarkers}
+                        showEventDots={showEventDots}
                       />
                     </div>
                   );

--- a/src/stores/timeline-preferences.ts
+++ b/src/stores/timeline-preferences.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type TimelinePreferencesState = {
+  showOpacityFade: boolean;
+  showReviewMarkers: boolean;
+  setShowOpacityFade: (value: boolean) => void;
+  setShowReviewMarkers: (value: boolean) => void;
+};
+
+export const useTimelinePreferencesStore = create<TimelinePreferencesState>()(
+  persist(
+    (set) => ({
+      showOpacityFade: true,
+      showReviewMarkers: false,
+      setShowOpacityFade: (value) => set({ showOpacityFade: value }),
+      setShowReviewMarkers: (value) => set({ showReviewMarkers: value })
+    }),
+    {
+      name: "timeline-preferences",
+      version: 1
+    }
+  )
+);

--- a/src/stores/timeline-preferences.ts
+++ b/src/stores/timeline-preferences.ts
@@ -4,23 +4,55 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 type TimelinePreferencesState = {
-  showOpacityFade: boolean;
+  showOpacityGradient: boolean;
   showReviewMarkers: boolean;
-  setShowOpacityFade: (value: boolean) => void;
+  showEventDots: boolean;
+  setShowOpacityGradient: (value: boolean) => void;
   setShowReviewMarkers: (value: boolean) => void;
+  setShowEventDots: (value: boolean) => void;
 };
 
 export const useTimelinePreferencesStore = create<TimelinePreferencesState>()(
   persist(
     (set) => ({
-      showOpacityFade: true,
+      showOpacityGradient: true,
       showReviewMarkers: false,
-      setShowOpacityFade: (value) => set({ showOpacityFade: value }),
-      setShowReviewMarkers: (value) => set({ showReviewMarkers: value })
+      showEventDots: true,
+      setShowOpacityGradient: (value) => set({ showOpacityGradient: value }),
+      setShowReviewMarkers: (value) => set({ showReviewMarkers: value }),
+      setShowEventDots: (value) => set({ showEventDots: value })
     }),
     {
       name: "timeline-preferences",
-      version: 1
+      version: 2,
+      migrate: (persistedState) => {
+        if (!persistedState || typeof persistedState !== "object") {
+          return persistedState as TimelinePreferencesState;
+        }
+
+        const state = persistedState as Partial<TimelinePreferencesState> & {
+          showOpacityFade?: boolean;
+        };
+
+        const showOpacityGradient =
+          typeof state.showOpacityGradient === "boolean"
+            ? state.showOpacityGradient
+            : typeof state.showOpacityFade === "boolean"
+              ? state.showOpacityFade
+              : true;
+
+        const showReviewMarkers =
+          typeof state.showReviewMarkers === "boolean" ? state.showReviewMarkers : false;
+
+        const showEventDots =
+          typeof state.showEventDots === "boolean" ? state.showEventDots : true;
+
+        return {
+          showOpacityGradient,
+          showReviewMarkers,
+          showEventDots
+        } as TimelinePreferencesState;
+      }
     }
   )
 );


### PR DESCRIPTION
## Summary
- persist timeline opacity and review marker preferences in a dedicated Zustand store
- expose toolbar toggles that control opacity fading and review marker visibility across all timeline charts
- ensure the chart hides review dots when markers are disabled and keep gradients only when fading is enabled

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e1922d3a34833180f0fd187ef8b539