### PR TITLE
Add tokenized light theme support

### DIFF
--- a/docs/ui-style-audit.md
+++ b/docs/ui-style-audit.md
@@ -83,7 +83,7 @@ Zoom controls, drag panning, and shift-scroll translate into domain updates that
 - Form controls: `rounded-lg border border-border bg-card/60 px-3 py-2 text-sm` and accent focus ring; the dashboard search input is elevated with `border-white/10 bg-slate-950/85` and includes quick-key hints.
 
 ## Card & Panel Treatments
-- Containers use `rounded-3xl`, translucent surfaces (`bg-white/5`), soft borders (`border-white/5`), `shadow-lg`–`shadow-2xl`, and `backdrop-blur`
+- Containers use `rounded-3xl`, translucent surfaces (`bg-white/5`), and soft borders (`border-white/5`)
 - Empty states: dashed borders `border-dashed border-white/10`, icon tiles `rounded-2xl bg-accent/20`
 
 ## Iconography

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "lucide-react": "^0.378.0",
         "nanoid": "^5.1.6",
         "next": "^14.2.3",
+        "next-themes": "^0.4.6",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "sonner": "^1.4.2",
@@ -5445,6 +5446,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lucide-react": "^0.378.0",
     "nanoid": "^5.1.6",
     "next": "^14.2.3",
+    "next-themes": "^0.4.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "sonner": "^1.4.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="light" suppressHydrationWarning>
       <body className={`${inter.variable} min-h-screen bg-bg text-fg`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <Toaster richColors position="top-right" />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import "./globals.css";
+import "@/styles/theme.css";
+import "@/styles/globals.css";
+import { ThemeProvider } from "next-themes";
 import { Toaster } from "sonner";
 import { AppShell } from "@/components/layout/app-shell";
 
@@ -18,9 +20,11 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.variable} min-h-screen bg-surface text-surface-foreground`}>        
-        <Toaster richColors position="top-right" />
-        <AppShell>{children}</AppShell>
+      <body className={`${inter.variable} min-h-screen bg-bg text-fg`}>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+          <Toaster richColors position="top-right" />
+          <AppShell>{children}</AppShell>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -32,14 +32,14 @@ export default function ReviewsPage() {
   return (
     <section className="space-y-6">
       <header className="flex flex-col gap-2">
-        <h1 className="text-3xl font-semibold text-white">Today’s Reviews</h1>
-        <p className="text-sm text-zinc-400">
+        <h1 className="text-3xl font-semibold text-fg">Today’s Reviews</h1>
+        <p className="text-sm text-muted-foreground">
           Focus on the topics that are due right now. Knock them out to keep your streak alive.
         </p>
       </header>
 
       {dueTopics.length === 0 ? (
-        <div className="rounded-3xl border border-white/5 bg-white/5 p-8 text-center text-sm text-zinc-300">
+        <div className="rounded-3xl border border-inverse/5 bg-inverse/5 p-8 text-center text-sm text-muted-foreground">
           <Clock className="mx-auto mb-3 h-8 w-8 text-accent" />
           You’re all caught up for today. Great work!
           <div className="mt-4 flex justify-center">
@@ -50,9 +50,9 @@ export default function ReviewsPage() {
         </div>
       ) : (
         <div className="space-y-4">
-          <div className="flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-zinc-300">
-            <span className="font-medium text-white">{dueTopics.length} topic{dueTopics.length === 1 ? "" : "s"} waiting</span>
-            <span className="text-xs text-zinc-400">Next up {formatRelativeToNow(dueTopics[0]!.nextReviewDate)}</span>
+          <div className="flex items-center justify-between rounded-2xl border border-inverse/10 bg-inverse/5 px-4 py-3 text-sm text-muted-foreground">
+            <span className="font-medium text-fg">{dueTopics.length} topic{dueTopics.length === 1 ? "" : "s"} waiting</span>
+            <span className="text-xs text-muted-foreground">Next up {formatRelativeToNow(dueTopics[0]!.nextReviewDate)}</span>
           </div>
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             {dueTopics.map((topic) => (

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -38,22 +38,22 @@ export default function SettingsPage() {
 
   const emailClasses = cn(
     "flex w-full items-center justify-between rounded-xl border px-3 py-2 text-left text-sm transition",
-    profile.notifications.email ? "border-accent/40 bg-accent/10 text-accent" : "border-white/10 text-zinc-400 hover:text-zinc-200"
+    profile.notifications.email ? "border-accent/40 bg-accent/10 text-accent" : "border-inverse/10 text-muted-foreground hover:text-fg/80"
   );
 
   const pushClasses = cn(
     "flex w-full items-center justify-between rounded-xl border px-3 py-2 text-left text-sm transition",
-    profile.notifications.push ? "border-accent/40 bg-accent/10 text-accent" : "border-white/10 text-zinc-400 hover:text-zinc-200"
+    profile.notifications.push ? "border-accent/40 bg-accent/10 text-accent" : "border-inverse/10 text-muted-foreground hover:text-fg/80"
   );
 
   return (
     <section className="space-y-6">
       <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-white">Profile settings</h1>
-        <p className="text-sm text-zinc-400">Keep your details and notification preferences up to date.</p>
+        <h1 className="text-3xl font-semibold text-fg">Profile settings</h1>
+        <p className="text-sm text-muted-foreground">Keep your details and notification preferences up to date.</p>
       </header>
 
-      <form onSubmit={handleSubmit} className="space-y-6 rounded-3xl border border-white/5 bg-slate-900/60 p-6 shadow-xl">
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-3xl border border-inverse/5 bg-card/60 p-6 shadow-xl">
         <div className="grid gap-4 md:grid-cols-2">
           <div className="space-y-2">
             <Label htmlFor="profile-name">Name</Label>
@@ -62,7 +62,7 @@ export default function SettingsPage() {
               value={form.name}
               onChange={handleChange("name")}
               placeholder="Your name"
-              className="h-11 rounded-2xl border-white/10 bg-white/10"
+              className="h-11 rounded-2xl border-inverse/10 bg-inverse/10"
             />
           </div>
           <div className="space-y-2">
@@ -73,7 +73,7 @@ export default function SettingsPage() {
               value={form.email}
               onChange={handleChange("email")}
               placeholder="you@example.com"
-              className="h-11 rounded-2xl border-white/10 bg-white/10"
+              className="h-11 rounded-2xl border-inverse/10 bg-inverse/10"
             />
           </div>
           <div className="space-y-2">
@@ -83,7 +83,7 @@ export default function SettingsPage() {
               value={form.role}
               onChange={handleChange("role")}
               placeholder="Learner"
-              className="h-11 rounded-2xl border-white/10 bg-white/10"
+              className="h-11 rounded-2xl border-inverse/10 bg-inverse/10"
             />
           </div>
           <div className="space-y-2">
@@ -93,9 +93,9 @@ export default function SettingsPage() {
               value={form.timezone}
               onChange={handleChange("timezone")}
               placeholder="UTC"
-              className="h-11 rounded-2xl border-white/10 bg-white/10"
+              className="h-11 rounded-2xl border-inverse/10 bg-inverse/10"
             />
-            <p className="text-xs text-zinc-500">
+            <p className="text-xs text-muted-foreground/80">
               We use this timezone for all date labels and to reset the daily revise limit at local midnight.
             </p>
           </div>
@@ -106,7 +106,7 @@ export default function SettingsPage() {
             <Label>Avatar colour</Label>
             <div className="mt-2 flex items-center gap-4">
               <span
-                className="flex h-12 w-12 items-center justify-center rounded-full text-sm font-semibold text-white"
+                className="flex h-12 w-12 items-center justify-center rounded-full text-sm font-semibold text-fg"
                 style={{ backgroundColor: form.avatarColor }}
               >
                 {initials}
@@ -114,8 +114,8 @@ export default function SettingsPage() {
               <ColorPicker value={form.avatarColor} onChange={(value) => setForm((prev) => ({ ...prev, avatarColor: value }))} />
             </div>
           </div>
-          <div className="space-y-2 rounded-2xl border border-white/10 bg-white/5 p-4 text-xs text-zinc-300">
-            <p className="text-sm font-semibold text-white">Notifications</p>
+          <div className="space-y-2 rounded-2xl border border-inverse/10 bg-inverse/5 p-4 text-xs text-muted-foreground">
+            <p className="text-sm font-semibold text-fg">Notifications</p>
             <button type="button" onClick={() => toggleNotification("email")} className={emailClasses}>
               <span className="flex items-center gap-2"><BellRing className="h-4 w-4" /> Email reminders</span>
               <span>{profile.notifications.email ? "On" : "Off"}</span>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -53,7 +53,7 @@ export default function SettingsPage() {
         <p className="text-sm text-muted-foreground">Keep your details and notification preferences up to date.</p>
       </header>
 
-      <form onSubmit={handleSubmit} className="space-y-6 rounded-3xl border border-inverse/5 bg-card/60 p-6 shadow-xl">
+      <form onSubmit={handleSubmit} className="space-y-6 rounded-3xl border border-inverse/5 bg-card/60 p-6">
         <div className="grid gap-4 md:grid-cols-2">
           <div className="space-y-2">
             <Label htmlFor="profile-name">Name</Label>

--- a/src/app/subjects/[subjectId]/history/page.tsx
+++ b/src/app/subjects/[subjectId]/history/page.tsx
@@ -170,7 +170,7 @@ const SubjectHistoryPage: React.FC<SubjectHistoryPageProps> = ({ params }) => {
           </span>
         </div>
 
-        <section className="space-y-4 rounded-3xl border border-inverse/10 bg-bg/80 p-6 shadow-2xl shadow-black/40">
+        <section className="space-y-4 rounded-3xl border border-inverse/10 bg-bg/80 p-6">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start gap-4">
               <span

--- a/src/app/subjects/[subjectId]/history/page.tsx
+++ b/src/app/subjects/[subjectId]/history/page.tsx
@@ -25,9 +25,9 @@ const QUALITY_LABEL: Record<ReviewQuality, string> = {
 };
 
 const QUALITY_TONE: Record<ReviewQuality, string> = {
-  1: "text-emerald-300",
-  0.5: "text-amber-300",
-  0: "text-rose-300"
+  1: "text-success/40",
+  0.5: "text-warn/40",
+  0: "text-error/40"
 };
 
 type SubjectReview = {
@@ -45,7 +45,7 @@ const resolveUrgency = (examDate: string | null | undefined) => {
   if (!examDate) {
     return {
       label: "No exam date",
-      tone: "bg-zinc-800/80 text-zinc-200",
+      tone: "bg-muted/80 text-fg/80",
       description: "Set an exam date to unlock countdowns and exam alerts.",
       daysLeft: null
     };
@@ -57,7 +57,7 @@ const resolveUrgency = (examDate: string | null | undefined) => {
   if (daysLeft < 0) {
     return {
       label: "Exam passed",
-      tone: "bg-zinc-800/80 text-zinc-200",
+      tone: "bg-muted/80 text-fg/80",
       description: "This exam date has passed. Plan a new milestone when you are ready.",
       daysLeft
     };
@@ -66,7 +66,7 @@ const resolveUrgency = (examDate: string | null | undefined) => {
   if (daysLeft <= 7) {
     return {
       label: "Urgent",
-      tone: "bg-rose-500/20 text-rose-100",
+      tone: "bg-error/20 text-error/20",
       description: "Exam is around the corner. Prioritise these reviews.",
       daysLeft
     };
@@ -75,7 +75,7 @@ const resolveUrgency = (examDate: string | null | undefined) => {
   if (daysLeft <= 30) {
     return {
       label: "Next up",
-      tone: "bg-amber-500/20 text-amber-100",
+      tone: "bg-warn/20 text-warn/20",
       description: "Exam is approaching. Keep momentum steady.",
       daysLeft
     };
@@ -83,7 +83,7 @@ const resolveUrgency = (examDate: string | null | undefined) => {
 
   return {
     label: "Plenty of time",
-    tone: "bg-emerald-500/20 text-emerald-100",
+    tone: "bg-success/20 text-success/20",
     description: "Planned well ahead. Maintain a consistent cadence.",
     daysLeft
   };
@@ -125,10 +125,10 @@ const SubjectHistoryPage: React.FC<SubjectHistoryPageProps> = ({ params }) => {
 
   if (!subject) {
     return (
-      <main className="flex min-h-screen flex-col items-center justify-center bg-slate-950/30 px-4 text-center">
+      <main className="flex min-h-screen flex-col items-center justify-center bg-bg/30 px-4 text-center">
         <div className="space-y-4">
-          <h1 className="text-2xl font-semibold text-white">Subject not found</h1>
-          <p className="text-sm text-zinc-400">
+          <h1 className="text-2xl font-semibold text-fg">Subject not found</h1>
+          <p className="text-sm text-muted-foreground">
             The subject you tried to open could not be located. It may have been removed or renamed.
           </p>
           <Button asChild variant="outline" className="gap-2">
@@ -155,35 +155,35 @@ const SubjectHistoryPage: React.FC<SubjectHistoryPageProps> = ({ params }) => {
   );
 
   return (
-    <main className="min-h-screen bg-slate-950/30 px-4 py-10">
+    <main className="min-h-screen bg-bg/30 px-4 py-10">
       <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
         <div className="flex items-center justify-between gap-4">
-          <Button asChild variant="ghost" size="sm" className="gap-2 text-zinc-300 hover:text-white">
+          <Button asChild variant="ghost" size="sm" className="gap-2 text-muted-foreground hover:text-fg">
             <Link href="/subjects">
               <ArrowLeft className="h-4 w-4" aria-hidden="true" /> Back to subjects
             </Link>
           </Button>
           <span
-            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-zinc-300"
+            className="inline-flex items-center gap-2 rounded-full border border-inverse/10 bg-inverse/5 px-3 py-1 text-xs text-muted-foreground"
           >
             <Layers className="h-3.5 w-3.5" aria-hidden="true" /> {topicCount} topic{topicCount === 1 ? "" : "s"}
           </span>
         </div>
 
-        <section className="space-y-4 rounded-3xl border border-white/10 bg-slate-950/80 p-6 shadow-2xl shadow-black/40">
+        <section className="space-y-4 rounded-3xl border border-inverse/10 bg-bg/80 p-6 shadow-2xl shadow-black/40">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start gap-4">
               <span
-                className="flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10"
+                className="flex h-14 w-14 items-center justify-center rounded-2xl border border-inverse/10"
                 style={{ backgroundColor: `${subject.color}22`, color: subject.color }}
                 aria-hidden="true"
               >
                 <IconPreview name={subject.icon} className="h-6 w-6" />
               </span>
               <div className="space-y-1">
-                <p className="text-xs uppercase tracking-wide text-zinc-400">Subject history</p>
-                <h1 className="text-3xl font-semibold text-white">{subject.name}</h1>
-                <p className="text-sm text-zinc-400">Chronological log of every review recorded for this subject.</p>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">Subject history</p>
+                <h1 className="text-3xl font-semibold text-fg">{subject.name}</h1>
+                <p className="text-sm text-muted-foreground">Chronological log of every review recorded for this subject.</p>
               </div>
             </div>
             <div className="flex flex-col items-start gap-2 text-sm sm:items-end">
@@ -191,48 +191,48 @@ const SubjectHistoryPage: React.FC<SubjectHistoryPageProps> = ({ params }) => {
                 <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
                 {urgency.label}
               </span>
-              <p className="text-zinc-300">
+              <p className="text-muted-foreground">
                 {subject.examDate ? formatFullDate(subject.examDate) : "No exam scheduled"}
               </p>
               {typeof urgency.daysLeft === "number" ? (
-                <p className="text-xs text-zinc-500">
+                <p className="text-xs text-muted-foreground/80">
                   {urgency.daysLeft >= 0 ? `${urgency.daysLeft} days left` : `${Math.abs(urgency.daysLeft)} days ago`}
                 </p>
               ) : null}
-              <p className="max-w-xs text-xs text-zinc-500 text-left sm:text-right">{urgency.description}</p>
+              <p className="max-w-xs text-xs text-muted-foreground/80 text-left sm:text-right">{urgency.description}</p>
             </div>
           </div>
-          <div className="grid gap-3 rounded-2xl border border-white/5 bg-slate-900/70 p-4 sm:grid-cols-3">
+          <div className="grid gap-3 rounded-2xl border border-inverse/5 bg-card/70 p-4 sm:grid-cols-3">
             <div className="space-y-1">
-              <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Recorded reviews</p>
-              <p className="text-2xl font-semibold text-white">{reviews.length}</p>
-              <p className="text-xs text-zinc-500">Each entry contributes to retention projections and exam readiness.</p>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Recorded reviews</p>
+              <p className="text-2xl font-semibold text-fg">{reviews.length}</p>
+              <p className="text-xs text-muted-foreground/80">Each entry contributes to retention projections and exam readiness.</p>
             </div>
             <div className="space-y-1">
-              <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Topics contributing</p>
-              <p className="text-2xl font-semibold text-white">{topicCount}</p>
-              <p className="text-xs text-zinc-500">Aggregated across every topic linked to this subject.</p>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Topics contributing</p>
+              <p className="text-2xl font-semibold text-fg">{topicCount}</p>
+              <p className="text-xs text-muted-foreground/80">Aggregated across every topic linked to this subject.</p>
             </div>
             <div className="space-y-1">
-              <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Most recent review</p>
-              <p className="text-lg font-semibold text-white">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Most recent review</p>
+              <p className="text-lg font-semibold text-fg">
                 {hasReviews ? formatDateWithWeekday(reviews[0].reviewDate) : "No reviews yet"}
               </p>
               {hasReviews ? (
-                <p className="text-xs text-zinc-500">
+                <p className="text-xs text-muted-foreground/80">
                   {formatRelativeToNow(reviews[0].reviewDate)} • {reviews[0].topicTitle}
                 </p>
               ) : (
-                <p className="text-xs text-zinc-500">Review history updates here once you log study sessions.</p>
+                <p className="text-xs text-muted-foreground/80">Review history updates here once you log study sessions.</p>
               )}
             </div>
           </div>
         </section>
 
-        <section className="rounded-3xl border border-white/10 bg-slate-950/70 p-6">
+        <section className="rounded-3xl border border-inverse/10 bg-bg/70 p-6">
           <div className="mb-4 flex items-center justify-between gap-4">
-            <h2 className="text-lg font-semibold text-white">Review timeline</h2>
-            <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-zinc-300">
+            <h2 className="text-lg font-semibold text-fg">Review timeline</h2>
+            <div className="inline-flex items-center gap-2 rounded-full border border-inverse/10 bg-inverse/5 px-3 py-1 text-xs text-muted-foreground">
               <NotebookPen className="h-3.5 w-3.5" aria-hidden="true" /> Chronological order
             </div>
           </div>
@@ -243,9 +243,9 @@ const SubjectHistoryPage: React.FC<SubjectHistoryPageProps> = ({ params }) => {
                 const label = formatDateWithWeekday(`${day}T00:00:00Z`);
                 return (
                   <li key={day} className="space-y-3">
-                    <div className="flex items-center gap-2 text-sm text-zinc-300">
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground">
                       <CalendarDays className="h-4 w-4" aria-hidden="true" />
-                      <span className="font-medium text-white">{label}</span>
+                      <span className="font-medium text-fg">{label}</span>
                     </div>
                     <ul className="space-y-3">
                       {entries
@@ -255,12 +255,12 @@ const SubjectHistoryPage: React.FC<SubjectHistoryPageProps> = ({ params }) => {
                           return (
                             <li
                               key={entry.id}
-                              className="rounded-2xl border border-white/10 bg-slate-900/80 p-4 text-sm text-zinc-300"
+                              className="rounded-2xl border border-inverse/10 bg-card/80 p-4 text-sm text-muted-foreground"
                             >
                               <div className="flex flex-wrap items-center justify-between gap-3">
                                 <div className="space-y-1">
-                                  <p className="text-base font-semibold text-white">{entry.topicTitle}</p>
-                                  <p className="text-xs text-zinc-500">
+                                  <p className="text-base font-semibold text-fg">{entry.topicTitle}</p>
+                                  <p className="text-xs text-muted-foreground/80">
                                     Logged {formatRelativeToNow(entry.reviewDate)} • {formatInTimeZone(entry.reviewDate, timezone, {
                                       hour: "numeric",
                                       minute: "2-digit"
@@ -272,14 +272,14 @@ const SubjectHistoryPage: React.FC<SubjectHistoryPageProps> = ({ params }) => {
                                     {QUALITY_LABEL[entry.quality]}
                                   </span>
                                   {typeof entry.intervalDays === "number" ? (
-                                    <span className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-1 text-xs text-zinc-200">
+                                    <span className="inline-flex items-center gap-2 rounded-full border border-inverse/10 px-3 py-1 text-xs text-fg/80">
                                       <Clock className="h-3.5 w-3.5" aria-hidden="true" /> {entry.intervalDays} day interval
                                     </span>
                                   ) : null}
                                 </div>
                               </div>
                               {entry.notes ? (
-                                <p className="mt-3 text-sm text-zinc-300">{entry.notes}</p>
+                                <p className="mt-3 text-sm text-muted-foreground">{entry.notes}</p>
                               ) : null}
                             </li>
                           );
@@ -290,10 +290,10 @@ const SubjectHistoryPage: React.FC<SubjectHistoryPageProps> = ({ params }) => {
               })}
             </ol>
           ) : (
-            <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-white/10 bg-slate-900/60 p-12 text-center">
-              <CalendarDays className="h-6 w-6 text-zinc-500" aria-hidden="true" />
-              <p className="text-sm font-medium text-white">No past reviews yet</p>
-              <p className="max-w-sm text-xs text-zinc-500">
+            <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-inverse/10 bg-card/60 p-12 text-center">
+              <CalendarDays className="h-6 w-6 text-muted-foreground/80" aria-hidden="true" />
+              <p className="text-sm font-medium text-fg">No past reviews yet</p>
+              <p className="max-w-sm text-xs text-muted-foreground/80">
                 Once you log study sessions for topics in this subject, they will appear here chronologically with cadence and quality details.
               </p>
             </div>

--- a/src/app/subjects/page.tsx
+++ b/src/app/subjects/page.tsx
@@ -337,7 +337,7 @@ const SubjectAdminPage: React.FC = () => {
         <Button
           size="lg"
           onClick={() => setIsCreateOpen(true)}
-          className="self-start rounded-full bg-accent px-6 py-3 text-base font-semibold shadow-[0_20px_60px_-20px_hsl(var(--accent)_/_0.6)] transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 md:absolute md:right-0 md:top-0"
+          className="self-start rounded-full bg-accent px-6 py-3 text-base font-semibold transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 md:absolute md:right-0 md:top-0"
           aria-haspopup="dialog"
           aria-expanded={isCreateOpen}
           aria-controls="create-subject-drawer"
@@ -393,7 +393,7 @@ const SubjectAdminPage: React.FC = () => {
               return (
                 <div
                   key={subject.id}
-                  className={`relative overflow-hidden rounded-3xl border border-inverse/10 bg-bg/70 p-6 shadow-xl shadow-slate-950/40 ${urgencyMeta.accentClass}`}
+                  className={`relative overflow-hidden rounded-3xl border border-inverse/10 bg-bg/70 p-6 ${urgencyMeta.accentClass}`}
                 >
                   <div
                     aria-hidden="true"
@@ -481,7 +481,7 @@ const SubjectAdminPage: React.FC = () => {
             return (
               <article
                 key={subject.id}
-                className={`relative overflow-hidden rounded-3xl border border-inverse/10 bg-bg/70 p-6 shadow-xl shadow-slate-950/40 ${urgencyMeta.accentClass}`}
+                className={`relative overflow-hidden rounded-3xl border border-inverse/10 bg-bg/70 p-6 ${urgencyMeta.accentClass}`}
               >
                 <div
                   aria-hidden="true"
@@ -705,7 +705,7 @@ const SubjectAdminPage: React.FC = () => {
             onClick={() => setIsCreateOpen(false)}
             aria-hidden="true"
           />
-          <aside className="relative ml-auto flex h-full w-full max-w-md flex-col overflow-y-auto bg-bg/95 p-6 shadow-2xl shadow-black/50">
+          <aside className="relative ml-auto flex h-full w-full max-w-md flex-col overflow-y-auto bg-bg/95 p-6">
             <div className="flex items-start justify-between gap-4">
               <div className="space-y-1">
                 <h2 className="text-2xl font-semibold text-fg">Create a subject</h2>

--- a/src/app/subjects/page.tsx
+++ b/src/app/subjects/page.tsx
@@ -3,6 +3,7 @@
 import * as React from "react";
 import Link from "next/link";
 import { useTopicStore } from "@/stores/topics";
+import { FALLBACK_SUBJECT_COLOR } from "@/lib/colors";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -54,9 +55,9 @@ const toDateInputValue = (value: string | null | undefined) => {
 type TopicStatus = "overdue" | "due-today" | "upcoming";
 
 const STATUS_META: Record<TopicStatus, { label: string; tone: string }> = {
-  overdue: { label: "Overdue", tone: "bg-rose-500/20 text-rose-100" },
-  "due-today": { label: "Due today", tone: "bg-amber-500/20 text-amber-100" },
-  upcoming: { label: "Upcoming", tone: "bg-sky-500/20 text-sky-100" }
+  overdue: { label: "Overdue", tone: "bg-error/20 text-error/20" },
+  "due-today": { label: "Due today", tone: "bg-warn/20 text-warn/20" },
+  upcoming: { label: "Upcoming", tone: "bg-accent/20 text-accent/20" }
 };
 
 const DEFAULT_SUBJECT_ID = "subject-general";
@@ -81,44 +82,44 @@ const getExamUrgencyMeta = (daysLeft: number | null): ExamUrgencyMeta => {
   if (daysLeft === null) {
     return {
       label: "No exam date",
-      badgeClass: "bg-zinc-800/80 text-zinc-200",
+      badgeClass: "bg-muted/80 text-fg/80",
       description: "Set an exam date to unlock countdowns and exam alerts.",
-      accentClass: "ring-1 ring-inset ring-zinc-700/40"
+      accentClass: "ring-1 ring-inset ring-border/60"
     };
   }
 
   if (daysLeft < 0) {
     return {
       label: "Exam passed",
-      badgeClass: "bg-zinc-800/80 text-zinc-200",
+      badgeClass: "bg-muted/80 text-fg/80",
       description: "This exam date has passed. Plan a new milestone when you are ready.",
-      accentClass: "ring-1 ring-inset ring-zinc-700/40"
+      accentClass: "ring-1 ring-inset ring-border/60"
     };
   }
 
   if (daysLeft <= 7) {
     return {
       label: "Urgent",
-      badgeClass: "bg-rose-500/20 text-rose-100",
+      badgeClass: "bg-error/20 text-error/20",
       description: "Exam is around the corner. Prioritise these reviews.",
-      accentClass: "ring-1 ring-inset ring-rose-400/40"
+      accentClass: "ring-1 ring-inset ring-error/40"
     };
   }
 
   if (daysLeft <= 30) {
     return {
       label: "Next up",
-      badgeClass: "bg-amber-500/20 text-amber-100",
+      badgeClass: "bg-warn/20 text-warn/20",
       description: "Exam is approaching. Keep momentum steady.",
-      accentClass: "ring-1 ring-inset ring-amber-300/40"
+      accentClass: "ring-1 ring-inset ring-warn/40"
     };
   }
 
   return {
     label: "Plenty of time",
-    badgeClass: "bg-emerald-500/20 text-emerald-100",
+    badgeClass: "bg-success/20 text-success/20",
     description: "Planned well ahead. Maintain a consistent cadence.",
-    accentClass: "ring-1 ring-inset ring-emerald-300/40"
+    accentClass: "ring-1 ring-inset ring-success/40"
   };
 };
 
@@ -133,10 +134,10 @@ const SubjectAdminPage: React.FC = () => {
 
   const [name, setName] = React.useState("");
   const [examDate, setExamDate] = React.useState("");
-  const [color, setColor] = React.useState("#38bdf8");
+  const [color, setColor] = React.useState(FALLBACK_SUBJECT_COLOR);
   const [icon, setIcon] = React.useState("Sparkles");
   const [editing, setEditing] = React.useState<string | null>(null);
-  const [editDraft, setEditDraft] = React.useState({ name: "", examDate: "", color: "#38bdf8", icon: "Sparkles" });
+  const [editDraft, setEditDraft] = React.useState({ name: "", examDate: "", color: FALLBACK_SUBJECT_COLOR, icon: "Sparkles" });
   const [expandedSubjects, setExpandedSubjects] = React.useState<Set<string>>(new Set());
   const [isCreateOpen, setIsCreateOpen] = React.useState(false);
   const [sortOption, setSortOption] = React.useState<SortOption>("urgency");
@@ -221,7 +222,7 @@ const SubjectAdminPage: React.FC = () => {
   const resetForm = () => {
     setName("");
     setExamDate("");
-    setColor("#38bdf8");
+    setColor(FALLBACK_SUBJECT_COLOR);
     setIcon("Sparkles");
   };
 
@@ -307,16 +308,16 @@ const SubjectAdminPage: React.FC = () => {
     <main className="relative mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-10 px-4 pb-24 pt-12 md:px-8 lg:px-10">
       <header className="relative flex flex-col gap-6 pb-8">
         <div className="space-y-3 pr-0 md:pr-64">
-          <h1 className="text-4xl font-semibold text-white">Subjects</h1>
-          <p className="text-sm text-zinc-400">
+          <h1 className="text-4xl font-semibold text-fg">Subjects</h1>
+          <p className="text-sm text-muted-foreground">
             Manage the subjects that power your review schedule, including exam dates and identity settings.
           </p>
         </div>
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-            <span className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Sort</span>
+            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">Sort</span>
             <Select value={sortOption} onValueChange={(value) => setSortOption(value as SortOption)}>
-              <SelectTrigger className="w-48 border-white/10 bg-white/5 text-white/90 backdrop-blur">
+              <SelectTrigger className="w-48 border-inverse/10 bg-inverse/5 text-fg/90 backdrop-blur">
                 <SelectValue placeholder="Sort subjects" />
               </SelectTrigger>
               <SelectContent>
@@ -329,14 +330,14 @@ const SubjectAdminPage: React.FC = () => {
               </SelectContent>
             </Select>
           </div>
-          <p className="text-xs text-zinc-500 sm:text-sm">
+          <p className="text-xs text-muted-foreground/80 sm:text-sm">
             {subjects.length} subject{subjects.length === 1 ? "" : "s"} tracked
           </p>
         </div>
         <Button
           size="lg"
           onClick={() => setIsCreateOpen(true)}
-          className="self-start rounded-full bg-accent px-6 py-3 text-base font-semibold shadow-[0_20px_60px_-20px_rgba(56,189,248,0.6)] transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 md:absolute md:right-0 md:top-0"
+          className="self-start rounded-full bg-accent px-6 py-3 text-base font-semibold shadow-[0_20px_60px_-20px_hsl(var(--accent)_/_0.6)] transition hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 md:absolute md:right-0 md:top-0"
           aria-haspopup="dialog"
           aria-expanded={isCreateOpen}
           aria-controls="create-subject-drawer"
@@ -347,8 +348,8 @@ const SubjectAdminPage: React.FC = () => {
 
       <section className="space-y-6">
         <div className="flex flex-col gap-2">
-          <h2 className="text-lg font-semibold text-white">Subjects overview</h2>
-          <p className="text-sm text-zinc-400">
+          <h2 className="text-lg font-semibold text-fg">Subjects overview</h2>
+          <p className="text-sm text-muted-foreground">
             Monitor exam timelines, review momentum, and drill into topics from a single place.
           </p>
         </div>
@@ -362,7 +363,7 @@ const SubjectAdminPage: React.FC = () => {
             const examDateValue = subject.examDate ? new Date(subject.examDate) : null;
             const daysLeft = examDateValue ? daysBetween(startOfToday, examDateValue) : null;
             const urgencyMeta = getExamUrgencyMeta(daysLeft);
-            const accentColor = (subject.color?.trim() || "#38bdf8") as string;
+            const accentColor = (subject.color?.trim() || FALLBACK_SUBJECT_COLOR) as string;
             const topicsCount = summary?.topicsCount ?? subjectTopics.length;
             const upcomingCount = summary?.upcomingReviewsCount ?? 0;
             const nextReviewAt = summary?.nextReviewAt ?? null;
@@ -392,7 +393,7 @@ const SubjectAdminPage: React.FC = () => {
               return (
                 <div
                   key={subject.id}
-                  className={`relative overflow-hidden rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-xl shadow-slate-950/40 ${urgencyMeta.accentClass}`}
+                  className={`relative overflow-hidden rounded-3xl border border-inverse/10 bg-bg/70 p-6 shadow-xl shadow-slate-950/40 ${urgencyMeta.accentClass}`}
                 >
                   <div
                     aria-hidden="true"
@@ -404,9 +405,9 @@ const SubjectAdminPage: React.FC = () => {
                   <div className="flex flex-col gap-6">
                     <div className="flex items-start justify-between gap-4">
                       <div>
-                        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">Editing</p>
-                        <h3 className="text-xl font-semibold text-white">{subject.name}</h3>
-                        <p className="text-sm text-zinc-400">Adjust the identity and exam target for this subject.</p>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">Editing</p>
+                        <h3 className="text-xl font-semibold text-fg">{subject.name}</h3>
+                        <p className="text-sm text-muted-foreground">Adjust the identity and exam target for this subject.</p>
                       </div>
                       <Button type="button" variant="ghost" onClick={handleCancelEdit}>
                         Cancel
@@ -420,7 +421,7 @@ const SubjectAdminPage: React.FC = () => {
                           value={editDraft.name}
                           onChange={(event) => setEditDraft((prev) => ({ ...prev, name: event.target.value }))}
                           placeholder="Subject name"
-                          className="h-11 rounded-xl border-white/10 bg-white/5 text-white"
+                          className="h-11 rounded-xl border-inverse/10 bg-inverse/5 text-fg"
                         />
                       </div>
                       <div className="space-y-2">
@@ -431,7 +432,7 @@ const SubjectAdminPage: React.FC = () => {
                           value={editDraft.examDate}
                           min={toDateInputValue(new Date().toISOString())}
                           onChange={(event) => setEditDraft((prev) => ({ ...prev, examDate: event.target.value }))}
-                          className="h-11 rounded-xl border-white/10 bg-white/5 text-white"
+                          className="h-11 rounded-xl border-inverse/10 bg-inverse/5 text-fg"
                         />
                       </div>
                     </div>
@@ -445,20 +446,20 @@ const SubjectAdminPage: React.FC = () => {
                         <ColorPicker value={editDraft.color} onChange={(value) => setEditDraft((prev) => ({ ...prev, color: value }))} />
                       </div>
                     </div>
-                    <div className="rounded-2xl border border-white/10 bg-slate-950/80 p-4">
-                      <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Live preview</p>
+                    <div className="rounded-2xl border border-inverse/10 bg-bg/80 p-4">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Live preview</p>
                       <div className="mt-3 flex items-center gap-3">
                         <span
-                          className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/5"
+                          className="flex h-12 w-12 items-center justify-center rounded-2xl border border-inverse/5"
                           style={{ backgroundColor: `${editDraft.color}22`, color: editDraft.color }}
                           aria-hidden="true"
                         >
                           <IconPreview name={editDraft.icon} className="h-5 w-5" />
                         </span>
-                        <div className="space-y-1 text-xs text-zinc-300">
-                          <p className="text-sm font-semibold text-white">{editDraft.name || "Untitled subject"}</p>
+                        <div className="space-y-1 text-xs text-muted-foreground">
+                          <p className="text-sm font-semibold text-fg">{editDraft.name || "Untitled subject"}</p>
                           <p>{previewExamLabel}</p>
-                          <p className="text-[11px] text-zinc-500">
+                          <p className="text-[11px] text-muted-foreground/80">
                             Saving applies the new identity to every topic in this subject.
                           </p>
                         </div>
@@ -480,7 +481,7 @@ const SubjectAdminPage: React.FC = () => {
             return (
               <article
                 key={subject.id}
-                className={`relative overflow-hidden rounded-3xl border border-white/10 bg-slate-950/70 p-6 shadow-xl shadow-slate-950/40 ${urgencyMeta.accentClass}`}
+                className={`relative overflow-hidden rounded-3xl border border-inverse/10 bg-bg/70 p-6 shadow-xl shadow-slate-950/40 ${urgencyMeta.accentClass}`}
               >
                 <div
                   aria-hidden="true"
@@ -493,15 +494,15 @@ const SubjectAdminPage: React.FC = () => {
                   <div className="flex flex-wrap items-start justify-between gap-4">
                     <div className="flex flex-1 items-start gap-4">
                       <span
-                        className="flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10"
+                        className="flex h-14 w-14 items-center justify-center rounded-2xl border border-inverse/10"
                         style={{ backgroundColor: `${accentColor}22`, color: accentColor }}
                         aria-hidden="true"
                       >
                         <IconPreview name={subject.icon} className="h-6 w-6" />
                       </span>
                       <div className="space-y-3">
-                        <h3 className="text-xl font-semibold text-white">{subject.name}</h3>
-                        <div className="space-y-2 text-sm text-zinc-300">
+                        <h3 className="text-xl font-semibold text-fg">{subject.name}</h3>
+                        <div className="space-y-2 text-sm text-muted-foreground">
                           <div className="flex flex-wrap items-center gap-2">
                             <span
                               className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${urgencyMeta.badgeClass}`}
@@ -510,12 +511,12 @@ const SubjectAdminPage: React.FC = () => {
                               {examBadgeText}
                             </span>
                             {subject.examDate ? (
-                              <span className="text-sm text-zinc-300">
+                              <span className="text-sm text-muted-foreground">
                                 Exam on {formatFullDate(subject.examDate)}
                                 {countdownText ? ` • ${countdownText}` : ""}
                               </span>
                             ) : (
-                              <span className="text-sm text-zinc-400">{urgencyMeta.description}</span>
+                              <span className="text-sm text-muted-foreground">{urgencyMeta.description}</span>
                             )}
                           </div>
                         </div>
@@ -526,7 +527,7 @@ const SubjectAdminPage: React.FC = () => {
                         type="button"
                         variant="outline"
                         size="sm"
-                        className="gap-2 border-white/10 bg-white/5 text-white hover:border-white/30 hover:bg-white/10"
+                        className="gap-2 border-inverse/10 bg-inverse/5 text-fg hover:border-inverse/30 hover:bg-inverse/10"
                         onClick={() => handleStartEdit(subject)}
                       >
                         <PencilLine className="h-4 w-4" /> Edit
@@ -535,7 +536,7 @@ const SubjectAdminPage: React.FC = () => {
                         type="button"
                         variant="ghost"
                         size="icon"
-                        className="text-rose-200 hover:text-rose-100"
+                        className="text-error/20 hover:text-error/20"
                         onClick={() => setSubjectPendingDelete(subject)}
                         disabled={hasTopics}
                         aria-label={
@@ -548,58 +549,58 @@ const SubjectAdminPage: React.FC = () => {
                   </div>
 
                   <div className="grid gap-3 sm:grid-cols-3">
-                    <div className="rounded-2xl border border-white/10 bg-slate-950/80 p-4">
-                      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-zinc-400">
+                    <div className="rounded-2xl border border-inverse/10 bg-bg/80 p-4">
+                      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                         <span>Topics</span>
-                        <BookOpen className="h-4 w-4 text-zinc-500" aria-hidden="true" />
+                        <BookOpen className="h-4 w-4 text-muted-foreground/80" aria-hidden="true" />
                       </div>
-                      <p className="mt-2 text-2xl font-semibold text-white">{topicsCount}</p>
+                      <p className="mt-2 text-2xl font-semibold text-fg">{topicsCount}</p>
                       {topicsCount === 0 ? (
                         <span
-                          className="mt-2 inline-flex items-center gap-1 text-xs text-zinc-500"
+                          className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground/80"
                           title="No topics yet. Create topics and assign them to this subject."
                         >
-                          <Info className="h-3.5 w-3.5 text-zinc-600" aria-hidden="true" />
+                          <Info className="h-3.5 w-3.5 text-muted-foreground/80" aria-hidden="true" />
                           No topics
                         </span>
                       ) : (
-                        <p className="mt-2 text-xs text-zinc-400">Active topics</p>
+                        <p className="mt-2 text-xs text-muted-foreground">Active topics</p>
                       )}
                     </div>
-                    <div className="rounded-2xl border border-white/10 bg-slate-950/80 p-4">
-                      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-zinc-400">
+                    <div className="rounded-2xl border border-inverse/10 bg-bg/80 p-4">
+                      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                         <span>Upcoming</span>
-                        <RefreshCw className="h-4 w-4 text-zinc-500" aria-hidden="true" />
+                        <RefreshCw className="h-4 w-4 text-muted-foreground/80" aria-hidden="true" />
                       </div>
-                      <p className="mt-2 text-2xl font-semibold text-white">{upcomingCount}</p>
+                      <p className="mt-2 text-2xl font-semibold text-fg">{upcomingCount}</p>
                       {upcomingCount === 0 ? (
                         <span
-                          className="mt-2 inline-flex items-center gap-1 text-xs text-zinc-500"
+                          className="mt-2 inline-flex items-center gap-1 text-xs text-muted-foreground/80"
                           title="No reviews scheduled in the next 7 days."
                         >
-                          <Info className="h-3.5 w-3.5 text-zinc-600" aria-hidden="true" />
+                          <Info className="h-3.5 w-3.5 text-muted-foreground/80" aria-hidden="true" />
                           No upcoming reviews
                         </span>
                       ) : (
-                        <p className="mt-2 text-xs text-zinc-400">Reviews next 7 days</p>
+                        <p className="mt-2 text-xs text-muted-foreground">Reviews next 7 days</p>
                       )}
                     </div>
-                    <div className="rounded-2xl border border-white/10 bg-slate-950/80 p-4">
-                      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-zinc-400">
+                    <div className="rounded-2xl border border-inverse/10 bg-bg/80 p-4">
+                      <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                         <span>Next review</span>
-                        <Clock className="h-4 w-4 text-zinc-500" aria-hidden="true" />
+                        <Clock className="h-4 w-4 text-muted-foreground/80" aria-hidden="true" />
                       </div>
-                      <p className="mt-2 text-sm font-semibold text-white">
+                      <p className="mt-2 text-sm font-semibold text-fg">
                         {nextReviewAt ? formatDateWithWeekday(nextReviewAt) : "--"}
                       </p>
                       {nextReviewAt ? (
-                        <p className="mt-1 text-xs text-zinc-400">{formatRelativeToNow(nextReviewAt)}</p>
+                        <p className="mt-1 text-xs text-muted-foreground">{formatRelativeToNow(nextReviewAt)}</p>
                       ) : (
                         <span
-                          className="mt-1 inline-flex items-center gap-1 text-xs text-zinc-500"
+                          className="mt-1 inline-flex items-center gap-1 text-xs text-muted-foreground/80"
                           title="Once a topic is due this will show the next review time."
                         >
-                          <Info className="h-3.5 w-3.5 text-zinc-600" aria-hidden="true" />
+                          <Info className="h-3.5 w-3.5 text-muted-foreground/80" aria-hidden="true" />
                           No upcoming reviews
                         </span>
                       )}
@@ -607,8 +608,8 @@ const SubjectAdminPage: React.FC = () => {
                   </div>
 
                   <div className="flex flex-wrap items-center justify-between gap-3">
-                    <div className="flex items-center gap-2 text-xs text-zinc-400">
-                      <Clock className="h-3.5 w-3.5 text-zinc-500" aria-hidden="true" />
+                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <Clock className="h-3.5 w-3.5 text-muted-foreground/80" aria-hidden="true" />
                       <span>{nextReviewLabel}</span>
                     </div>
                     <div className="flex items-center gap-2">
@@ -616,7 +617,7 @@ const SubjectAdminPage: React.FC = () => {
                         type="button"
                         variant="ghost"
                         size="sm"
-                        className="gap-2 text-white/80 hover:text-white"
+                        className="gap-2 text-fg/80 hover:text-fg"
                         onClick={() => toggleSubjectExpansion(subject.id)}
                         aria-expanded={isExpanded}
                         aria-controls={`subject-topics-${subject.id}`}
@@ -630,11 +631,11 @@ const SubjectAdminPage: React.FC = () => {
                   {isExpanded ? (
                     <div
                       id={`subject-topics-${subject.id}`}
-                      className="mt-4 space-y-3 rounded-2xl border border-white/10 bg-slate-950/80 p-4"
+                      className="mt-4 space-y-3 rounded-2xl border border-inverse/10 bg-bg/80 p-4"
                     >
                       {subjectTopics.length === 0 ? (
-                        <div className="flex items-center gap-2 text-sm text-zinc-400">
-                          <Info className="h-4 w-4 text-zinc-500" aria-hidden="true" />
+                        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                          <Info className="h-4 w-4 text-muted-foreground/80" aria-hidden="true" />
                           No topics assigned yet.
                         </div>
                       ) : (
@@ -646,11 +647,11 @@ const SubjectAdminPage: React.FC = () => {
                           return (
                             <div
                               key={topic.id}
-                              className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-slate-950/90 p-4 md:flex-row md:items-center md:justify-between"
+                              className="flex flex-col gap-3 rounded-2xl border border-inverse/10 bg-bg/90 p-4 md:flex-row md:items-center md:justify-between"
                             >
                               <div className="min-w-0 space-y-1">
-                                <p className="text-sm font-semibold text-white">{topic.title}</p>
-                                <p className="text-xs text-zinc-400">
+                                <p className="text-sm font-semibold text-fg">{topic.title}</p>
+                                <p className="text-xs text-muted-foreground">
                                   Next {nextDateLabel} • {nextRelative}
                                 </p>
                               </div>
@@ -664,7 +665,7 @@ const SubjectAdminPage: React.FC = () => {
                                   asChild
                                   size="sm"
                                   variant="outline"
-                                  className="gap-2 border-white/10 bg-white/5 text-white hover:border-white/30 hover:bg-white/10"
+                                  className="gap-2 border-inverse/10 bg-inverse/5 text-fg hover:border-inverse/30 hover:bg-inverse/10"
                                 >
                                   <Link href={`/subjects/${subject.id}/history`}>
                                     <Clock className="h-4 w-4" aria-hidden="true" /> Review history
@@ -684,9 +685,9 @@ const SubjectAdminPage: React.FC = () => {
         </div>
 
         {sortedSubjects.length === 0 ? (
-          <div className="rounded-3xl border border-dashed border-white/10 bg-slate-950/60 p-10 text-center text-sm text-zinc-400">
+          <div className="rounded-3xl border border-dashed border-inverse/10 bg-bg/60 p-10 text-center text-sm text-muted-foreground">
             <p className="mx-auto max-w-sm">
-              You haven’t created any subjects yet. Use the <span className="font-semibold text-white">New Subject</span> button to get started.
+              You haven’t created any subjects yet. Use the <span className="font-semibold text-fg">New Subject</span> button to get started.
             </p>
           </div>
         ) : null}
@@ -704,11 +705,11 @@ const SubjectAdminPage: React.FC = () => {
             onClick={() => setIsCreateOpen(false)}
             aria-hidden="true"
           />
-          <aside className="relative ml-auto flex h-full w-full max-w-md flex-col overflow-y-auto bg-slate-950/95 p-6 shadow-2xl shadow-black/50">
+          <aside className="relative ml-auto flex h-full w-full max-w-md flex-col overflow-y-auto bg-bg/95 p-6 shadow-2xl shadow-black/50">
             <div className="flex items-start justify-between gap-4">
               <div className="space-y-1">
-                <h2 className="text-2xl font-semibold text-white">Create a subject</h2>
-                <p className="text-sm text-zinc-400">
+                <h2 className="text-2xl font-semibold text-fg">Create a subject</h2>
+                <p className="text-sm text-muted-foreground">
                   Subjects group related topics and enforce exam date cutoffs.
                 </p>
               </div>
@@ -726,7 +727,7 @@ const SubjectAdminPage: React.FC = () => {
                   value={name}
                   onChange={(event) => setName(event.target.value)}
                   placeholder="e.g., Organic Chemistry"
-                  className="h-11 rounded-xl border-white/10 bg-white/5 text-white"
+                  className="h-11 rounded-xl border-inverse/10 bg-inverse/5 text-fg"
                 />
               </div>
               <div className="space-y-2">
@@ -737,9 +738,9 @@ const SubjectAdminPage: React.FC = () => {
                   value={examDate}
                   min={toDateInputValue(new Date().toISOString())}
                   onChange={(event) => setExamDate(event.target.value)}
-                  className="h-11 rounded-xl border-white/10 bg-white/5 text-white"
+                  className="h-11 rounded-xl border-inverse/10 bg-inverse/5 text-fg"
                 />
-                <p className="text-xs text-zinc-500">
+                <p className="text-xs text-muted-foreground/80">
                   Set the exam date for this subject to optimise your review schedule. No reviews will be scheduled after the exam.
                 </p>
               </div>
@@ -753,20 +754,20 @@ const SubjectAdminPage: React.FC = () => {
                   <ColorPicker value={color} onChange={setColor} />
                 </div>
               </div>
-              <div className="rounded-2xl border border-white/10 bg-slate-950/80 p-4">
-                <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Live preview</p>
+              <div className="rounded-2xl border border-inverse/10 bg-bg/80 p-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Live preview</p>
                 <div className="mt-3 flex items-start gap-3">
                   <span
-                    className="flex h-12 w-12 items-center justify-center rounded-2xl border border-white/5"
+                    className="flex h-12 w-12 items-center justify-center rounded-2xl border border-inverse/5"
                     style={{ backgroundColor: `${color}22`, color }}
                     aria-hidden="true"
                   >
                     <IconPreview name={icon} className="h-5 w-5" />
                   </span>
-                  <div className="space-y-1 text-xs text-zinc-300">
-                    <p className="text-sm font-semibold text-white">{name || "Untitled subject"}</p>
+                  <div className="space-y-1 text-xs text-muted-foreground">
+                    <p className="text-sm font-semibold text-fg">{name || "Untitled subject"}</p>
                     <p>{examDate ? formatFullDate(examDate) : "No exam date"}</p>
-                    <p className="text-[11px] text-zinc-500">Topics created in this subject will use this identity.</p>
+                    <p className="text-[11px] text-muted-foreground/80">Topics created in this subject will use this identity.</p>
                   </div>
                 </div>
               </div>

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -7,8 +7,8 @@ export default function TimelinePage() {
   return (
     <section className="space-y-6">
       <header className="space-y-2">
-        <h1 className="text-3xl font-semibold text-white">Timeline</h1>
-        <p className="text-sm text-zinc-400">
+        <h1 className="text-3xl font-semibold text-fg">Timeline</h1>
+        <p className="text-sm text-muted-foreground">
           Visualise upcoming reviews alongside retention curves to plan your study sessions with confidence.
         </p>
       </header>

--- a/src/app/topics/[id]/edit/page.tsx
+++ b/src/app/topics/[id]/edit/page.tsx
@@ -23,7 +23,7 @@ export default function EditTopicPage() {
   if (!topic) {
     return (
       <main className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-6 px-4 py-12 md:px-6 lg:px-8">
-        <div className="rounded-3xl border border-inverse/5 bg-card/60 p-8 text-center shadow-xl">
+        <div className="rounded-3xl border border-inverse/5 bg-card/60 p-8 text-center">
           <h1 className="text-2xl font-semibold text-fg">Topic unavailable</h1>
           <p className="mt-2 text-sm text-muted-foreground">
             We couldn&apos;t find that topic. It might have been removed or hasn&apos;t been created yet.

--- a/src/app/topics/[id]/edit/page.tsx
+++ b/src/app/topics/[id]/edit/page.tsx
@@ -23,9 +23,9 @@ export default function EditTopicPage() {
   if (!topic) {
     return (
       <main className="mx-auto flex min-h-screen w-full max-w-3xl flex-col gap-6 px-4 py-12 md:px-6 lg:px-8">
-        <div className="rounded-3xl border border-white/5 bg-slate-900/60 p-8 text-center shadow-xl">
-          <h1 className="text-2xl font-semibold text-white">Topic unavailable</h1>
-          <p className="mt-2 text-sm text-zinc-400">
+        <div className="rounded-3xl border border-inverse/5 bg-card/60 p-8 text-center shadow-xl">
+          <h1 className="text-2xl font-semibold text-fg">Topic unavailable</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
             We couldn&apos;t find that topic. It might have been removed or hasn&apos;t been created yet.
           </p>
           <Button className="mt-6 rounded-2xl" onClick={() => router.push("/")}>
@@ -45,13 +45,13 @@ export default function EditTopicPage() {
               <PenSquare className="h-4 w-4" /> Editing topic
             </div>
             <div className="space-y-2">
-              <h1 className="text-3xl font-semibold text-white md:text-4xl">{topic.title}</h1>
-              <p className="max-w-2xl text-sm text-zinc-300">
+              <h1 className="text-3xl font-semibold text-fg md:text-4xl">{topic.title}</h1>
+              <p className="max-w-2xl text-sm text-muted-foreground">
                 Adjust reminders, intervals, and notes. Your progress history stays intact.
               </p>
             </div>
           </div>
-          <Button variant="ghost" className="rounded-2xl text-zinc-300 hover:text-white" onClick={() => router.push("/")}>
+          <Button variant="ghost" className="rounded-2xl text-muted-foreground hover:text-fg" onClick={() => router.push("/")}>
             <ArrowLeft className="mr-2 h-4 w-4" /> Back to dashboard
           </Button>
         </div>

--- a/src/app/topics/new/page.tsx
+++ b/src/app/topics/new/page.tsx
@@ -22,13 +22,13 @@ export default function NewTopicPage() {
               <Sparkles className="h-4 w-4" /> New learning track
             </div>
             <div className="space-y-2">
-              <h1 className="text-3xl font-semibold text-white md:text-4xl">Create a new topic</h1>
-              <p className="max-w-2xl text-sm text-zinc-300">
+              <h1 className="text-3xl font-semibold text-fg md:text-4xl">Create a new topic</h1>
+              <p className="max-w-2xl text-sm text-muted-foreground">
                 Follow the guided steps to set up reminders, review intervals, and notes so your future self always knows what to study next.
               </p>
             </div>
           </div>
-          <Button variant="ghost" className="rounded-2xl text-zinc-300 hover:text-white" onClick={() => router.push("/")}>
+          <Button variant="ghost" className="rounded-2xl text-muted-foreground hover:text-fg" onClick={() => router.push("/")}>
             <ArrowLeft className="mr-2 h-4 w-4" /> Back to dashboard
           </Button>
         </div>

--- a/src/components/calendar/calendar-day-sheet.tsx
+++ b/src/components/calendar/calendar-day-sheet.tsx
@@ -135,7 +135,7 @@ export function CalendarDaySheet({
   const overlay = (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-[1200] flex items-end justify-center bg-slate-950/80 px-4 pb-[max(env(safe-area-inset-bottom),20px)] pt-6 backdrop-blur-sm transition sm:items-center sm:px-6"
+      className="fixed inset-0 z-[1200] flex items-end justify-center bg-bg/80 px-4 pb-[max(env(safe-area-inset-bottom),20px)] pt-6 backdrop-blur-sm transition sm:items-center sm:px-6"
       role="presentation"
       onMouseDown={(event) => {
         if (event.target === overlayRef.current) {
@@ -148,12 +148,12 @@ export function CalendarDaySheet({
         role="dialog"
         aria-modal="true"
         aria-labelledby="calendar-day-sheet-title"
-        className="relative flex w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-white/10 bg-slate-900/95 text-white shadow-2xl"
+        className="relative flex w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-inverse/10 bg-card/95 text-fg shadow-2xl"
       >
-        <header className="flex items-start justify-between gap-4 border-b border-white/5 px-6 py-5">
+        <header className="flex items-start justify-between gap-4 border-b border-inverse/5 px-6 py-5">
           <div className="space-y-2">
-            <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-zinc-400">
-              <span id="calendar-day-sheet-title" className="font-semibold text-white">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-muted-foreground">
+              <span id="calendar-day-sheet-title" className="font-semibold text-fg">
                 {formattedDate}
               </span>
               {day.isToday ? (
@@ -163,13 +163,13 @@ export function CalendarDaySheet({
               ) : null}
             </div>
             {day.hasOverdueBacklog ? (
-              <div className="inline-flex items-center gap-2 rounded-full bg-rose-500/15 px-3 py-1 text-[11px] font-semibold text-rose-200">
+              <div className="inline-flex items-center gap-2 rounded-full bg-error/15 px-3 py-1 text-[11px] font-semibold text-error/20">
                 <AlertTriangle className="h-3 w-3" aria-hidden="true" />
                 Overdue reviews waiting
               </div>
             ) : null}
             {day.hasExam && day.examSubjects.length > 0 ? (
-              <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-200" aria-label="Exam markers">
+              <div className="flex flex-wrap items-center gap-2 text-xs text-fg/80" aria-label="Exam markers">
                 {day.examSubjects.map((entry) => {
                   const examLabel = `Exam: ${entry.name} — ${fullExamDate}`;
                   return (
@@ -188,7 +188,7 @@ export function CalendarDaySheet({
               </div>
             ) : null}
             {showCapacityHint ? (
-              <p className="text-xs font-medium text-amber-200">
+              <p className="text-xs font-medium text-warn/30">
                 Busy day ahead — consider reviewing some items earlier.
               </p>
             ) : null}
@@ -199,14 +199,14 @@ export function CalendarDaySheet({
             size="icon"
             onClick={onClose}
             aria-label="Close day details"
-            className="rounded-full border border-white/15 text-zinc-300 hover:text-white"
+            className="rounded-full border border-inverse/15 text-muted-foreground hover:text-fg"
           >
             <X className="h-4 w-4" />
           </Button>
         </header>
         <div className="custom-scrollbar flex max-h-[70vh] flex-col gap-6 overflow-y-auto px-6 py-6 sm:max-h-[60vh]">
           {subjectsForDay.length === 0 ? (
-            <p className="text-sm text-zinc-300">No reviews scheduled for this day.</p>
+            <p className="text-sm text-muted-foreground">No reviews scheduled for this day.</p>
           ) : (
             subjectsForDay.map((entry) => (
               <section key={entry.subject.id} className="space-y-3">
@@ -218,8 +218,8 @@ export function CalendarDaySheet({
                     <IconPreview name={entry.subject.icon} className="h-5 w-5" />
                   </span>
                   <div>
-                    <p className="font-semibold text-white">{entry.subject.name}</p>
-                    <p className="text-xs text-zinc-400">{entry.count} {entry.count === 1 ? "topic" : "topics"} scheduled</p>
+                    <p className="font-semibold text-fg">{entry.subject.name}</p>
+                    <p className="text-xs text-muted-foreground">{entry.count} {entry.count === 1 ? "topic" : "topics"} scheduled</p>
                   </div>
                 </div>
                 <ul className="space-y-3">
@@ -235,12 +235,12 @@ export function CalendarDaySheet({
                       return (
                         <li
                           key={topic.id}
-                          className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-zinc-100"
+                          className="rounded-2xl border border-inverse/10 bg-inverse/5 px-4 py-3 text-sm text-inverse"
                         >
                           <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                             <div>
-                              <p className="font-medium text-white">{topic.title}</p>
-                              <p className="text-xs text-zinc-400">
+                              <p className="font-medium text-fg">{topic.title}</p>
+                              <p className="text-xs text-muted-foreground">
                                 Next review window: {dueTimeLabel}
                               </p>
                             </div>
@@ -260,16 +260,16 @@ export function CalendarDaySheet({
                                   size="sm"
                                   variant="outline"
                                   disabled
-                                  className="rounded-full border-dashed text-zinc-400"
+                                  className="rounded-full border-dashed text-muted-foreground"
                                   title={allowance.message}
                                 >
                                   {allowance.message ?? "Not available"}
                                 </Button>
                               )
                             ) : day.isPast ? (
-                              <span className="text-xs font-medium text-amber-200">Missed - catch up anytime.</span>
+                              <span className="text-xs font-medium text-warn/30">Missed - catch up anytime.</span>
                             ) : (
-                              <span className="text-xs text-zinc-400">Scheduled for this day.</span>
+                              <span className="text-xs text-muted-foreground">Scheduled for this day.</span>
                             )}
                           </div>
                         </li>

--- a/src/components/calendar/calendar-day-sheet.tsx
+++ b/src/components/calendar/calendar-day-sheet.tsx
@@ -148,7 +148,7 @@ export function CalendarDaySheet({
         role="dialog"
         aria-modal="true"
         aria-labelledby="calendar-day-sheet-title"
-        className="relative flex w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-inverse/10 bg-card/95 text-fg shadow-2xl"
+        className="relative flex w-full max-w-2xl flex-col overflow-hidden rounded-3xl border border-inverse/10 bg-card/95 text-fg"
       >
         <header className="flex items-start justify-between gap-4 border-b border-inverse/5 px-6 py-5">
           <div className="space-y-2">

--- a/src/components/calendar/calendar-view.tsx
+++ b/src/components/calendar/calendar-view.tsx
@@ -366,23 +366,23 @@ export function CalendarView() {
 
   return (
     <div className="flex flex-col gap-6">
-      <header className="flex flex-col gap-4 rounded-3xl border border-white/10 bg-slate-900/60 p-5 text-white shadow-lg backdrop-blur">
+      <header className="flex flex-col gap-4 rounded-3xl border border-inverse/10 bg-card/60 p-5 text-fg shadow-lg backdrop-blur">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="inline-flex items-center gap-3">
             <CalendarIcon className="h-5 w-5 text-accent" aria-hidden="true" />
             <h1 className="text-lg font-semibold">Calendar</h1>
           </div>
-          <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 p-1 text-xs">
+          <div className="inline-flex items-center gap-2 rounded-full border border-inverse/10 bg-inverse/5 p-1 text-xs">
             <button
               type="button"
-              className="rounded-full px-3 py-1 text-white"
+              className="rounded-full px-3 py-1 text-fg"
               aria-pressed="true"
             >
               Month
             </button>
             <button
               type="button"
-              className="rounded-full px-3 py-1 text-zinc-500"
+              className="rounded-full px-3 py-1 text-muted-foreground/80"
               aria-pressed="false"
               title="Week view coming soon"
               disabled
@@ -391,7 +391,7 @@ export function CalendarView() {
             </button>
             <button
               type="button"
-              className="rounded-full px-3 py-1 text-zinc-500"
+              className="rounded-full px-3 py-1 text-muted-foreground/80"
               aria-pressed="false"
               title="Agenda view coming soon"
               disabled
@@ -400,13 +400,13 @@ export function CalendarView() {
             </button>
           </div>
         </div>
-        <div className="flex flex-wrap items-center gap-3 text-sm text-zinc-300">
+        <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
           <div className="inline-flex items-center gap-2">
             <Button
               type="button"
               size="icon"
               variant="ghost"
-              className="rounded-full border border-white/10"
+              className="rounded-full border border-inverse/10"
               onClick={() => handleMonthChange(-1)}
               aria-label="Previous month"
             >
@@ -416,14 +416,14 @@ export function CalendarView() {
               type="button"
               size="icon"
               variant="ghost"
-              className="rounded-full border border-white/10"
+              className="rounded-full border border-inverse/10"
               onClick={() => handleMonthChange(1)}
               aria-label="Next month"
             >
               <ChevronRight className="h-4 w-4" />
             </Button>
           </div>
-          <div className="flex items-center gap-3 text-base font-semibold text-white">
+          <div className="flex items-center gap-3 text-base font-semibold text-fg">
             {monthLabel}
           </div>
           <Button
@@ -431,7 +431,7 @@ export function CalendarView() {
             variant="outline"
             size="sm"
             onClick={handleJumpToToday}
-            className="rounded-full border-white/20"
+            className="rounded-full border-inverse/20"
           >
             Jump to today
           </Button>
@@ -441,14 +441,14 @@ export function CalendarView() {
                 type="button"
                 variant="ghost"
                 size="sm"
-                className="inline-flex items-center gap-2 rounded-full border border-white/10"
+                className="inline-flex items-center gap-2 rounded-full border border-inverse/10"
               >
                 <Filter className="h-4 w-4" />
                 {subjectFilterLabel}
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-64 rounded-2xl border border-white/10 bg-slate-900/95 p-3 text-sm text-white">
-              <div className="mb-3 flex items-center justify-between text-xs text-zinc-300">
+            <PopoverContent className="w-64 rounded-2xl border border-inverse/10 bg-card/95 p-3 text-sm text-fg">
+              <div className="mb-3 flex items-center justify-between text-xs text-muted-foreground">
                 <button
                   type="button"
                   className="font-semibold text-accent"
@@ -466,7 +466,7 @@ export function CalendarView() {
                   return (
                     <label
                       key={subject.id}
-                      className="flex items-center gap-3 rounded-2xl border border-white/5 bg-white/5 px-3 py-2 text-xs hover:border-white/20"
+                      className="flex items-center gap-3 rounded-2xl border border-inverse/5 bg-inverse/5 px-3 py-2 text-xs hover:border-inverse/20"
                     >
                       <input
                         type="checkbox"
@@ -475,8 +475,8 @@ export function CalendarView() {
                         onChange={() => toggleSubject(subject.id)}
                       />
                       <span className="inline-flex h-3 w-3 rounded-full" style={{ backgroundColor: subject.color }} />
-                      <span className="flex-1 text-white">{subject.name}</span>
-                      <span className="text-[11px] text-zinc-400">{subject.count}</span>
+                      <span className="flex-1 text-fg">{subject.name}</span>
+                      <span className="text-[11px] text-muted-foreground">{subject.count}</span>
                     </label>
                   );
                 })}
@@ -487,22 +487,22 @@ export function CalendarView() {
       </header>
 
       {hasSubjects ? (
-        <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-4 text-white shadow-sm">
-          <div className="flex flex-wrap items-center gap-3 border-b border-white/5 pb-3 text-xs uppercase tracking-wide text-zinc-400">
+        <div className="rounded-3xl border border-inverse/10 bg-bg/70 p-4 text-fg shadow-sm">
+          <div className="flex flex-wrap items-center gap-3 border-b border-inverse/5 pb-3 text-xs uppercase tracking-wide text-muted-foreground">
             <span>Subjects</span>
             {subjectOptions.map((subject) => (
               <span
                 key={subject.id}
-                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1"
+                className="inline-flex items-center gap-2 rounded-full border border-inverse/10 bg-inverse/5 px-3 py-1"
                 title={formatSubjectTooltip(subject)}
               >
                 <span className="inline-flex h-2.5 w-2.5 rounded-full" style={{ backgroundColor: subject.color }} />
-                <span className="text-[11px] text-zinc-200">{subject.name}</span>
+                <span className="text-[11px] text-fg/80">{subject.name}</span>
               </span>
             ))}
           </div>
           <div className="mt-4">
-            <div className="grid grid-cols-7 gap-1 text-[11px] font-semibold uppercase tracking-wide text-zinc-500">
+            <div className="grid grid-cols-7 gap-1 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/80">
               {WEEKDAY_LABELS.map((label) => (
                 <div key={label} className="px-2 py-2 text-center">
                   {label}
@@ -557,8 +557,8 @@ export function CalendarView() {
                         onFocus={() => setFocusedDayKey(day.dayKey)}
                         onKeyDown={(event) => handleDayKeyDown(event, day)}
                         onClick={() => handleDaySelect(day)}
-                        className={`flex h-28 flex-col justify-between rounded-2xl border border-white/5 bg-slate-900/70 p-3 text-left transition hover:border-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
-                          day.isCurrentMonth ? "text-white" : "text-zinc-500"
+                        className={`flex h-28 flex-col justify-between rounded-2xl border border-inverse/5 bg-card/70 p-3 text-left transition hover:border-inverse/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent ${
+                          day.isCurrentMonth ? "text-fg" : "text-muted-foreground/80"
                         } ${day.isToday ? "ring-2 ring-accent/80" : ""}`}
                       >
                         <div className="flex items-center justify-between">
@@ -566,7 +566,7 @@ export function CalendarView() {
                             {day.dayNumberLabel}
                           </span>
                           {day.hasOverdueBacklog ? (
-                            <span className="inline-flex h-2.5 w-2.5 items-center justify-center rounded-full bg-rose-500" aria-hidden="true" />
+                            <span className="inline-flex h-2.5 w-2.5 items-center justify-center rounded-full bg-error" aria-hidden="true" />
                           ) : null}
                         </div>
                         <div className="flex flex-col gap-2">
@@ -574,7 +574,7 @@ export function CalendarView() {
                             {day.subjects.slice(0, MAX_VISIBLE_DOTS).map((entry) => (
                               <span
                                 key={entry.subject.id}
-                                className="inline-flex h-2.5 w-2.5 items-center justify-center rounded-full border border-white/20"
+                                className="inline-flex h-2.5 w-2.5 items-center justify-center rounded-full border border-inverse/20"
                                 style={{ backgroundColor: entry.subject.color }}
                                 title={formatSubjectTooltip({
                                   name: entry.subject.name,
@@ -586,7 +586,7 @@ export function CalendarView() {
                             ))}
                             {overflowCount > 0 ? (
                               <span
-                                className="inline-flex items-center rounded-full bg-white/10 px-1.5 py-0.5 text-[11px] text-white"
+                                className="inline-flex items-center rounded-full bg-inverse/10 px-1.5 py-0.5 text-[11px] text-fg"
                                 title={overflowTooltip(overflowSubjects)}
                                 role="img"
                                 aria-label={`+${overflowCount} more subjects with reviews on ${fullDate}: ${overflowTooltip(
@@ -599,7 +599,7 @@ export function CalendarView() {
                           </div>
                           {day.hasExam ? (
                             <span
-                              className="w-fit rounded-full border border-dashed border-white/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-white"
+                              className="w-fit rounded-full border border-dashed border-inverse/20 px-2 py-0.5 text-[10px] uppercase tracking-wide text-fg"
                               title={day.examSubjects
                                 .map((entry) => formatExamTooltip(entry.name, examDateLabel))
                                 .join("\n")}
@@ -621,7 +621,7 @@ export function CalendarView() {
           </div>
         </div>
       ) : (
-        <div className="rounded-3xl border border-white/10 bg-slate-950/70 p-8 text-center text-sm text-zinc-300">
+        <div className="rounded-3xl border border-inverse/10 bg-bg/70 p-8 text-center text-sm text-muted-foreground">
           No scheduled reviews this month. Try another month or add topics.
         </div>
       )}

--- a/src/components/calendar/calendar-view.tsx
+++ b/src/components/calendar/calendar-view.tsx
@@ -366,7 +366,7 @@ export function CalendarView() {
 
   return (
     <div className="flex flex-col gap-6">
-      <header className="flex flex-col gap-4 rounded-3xl border border-inverse/10 bg-card/60 p-5 text-fg shadow-lg backdrop-blur">
+      <header className="flex flex-col gap-4 rounded-3xl border border-inverse/10 bg-card/60 p-5 text-fg backdrop-blur">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="inline-flex items-center gap-3">
             <CalendarIcon className="h-5 w-5 text-accent" aria-hidden="true" />
@@ -487,7 +487,7 @@ export function CalendarView() {
       </header>
 
       {hasSubjects ? (
-        <div className="rounded-3xl border border-inverse/10 bg-bg/70 p-4 text-fg shadow-sm">
+        <div className="rounded-3xl border border-inverse/10 bg-bg/70 p-4 text-fg">
           <div className="flex flex-wrap items-center gap-3 border-b border-inverse/5 pb-3 text-xs uppercase tracking-wide text-muted-foreground">
             <span>Subjects</span>
             {subjectOptions.map((subject) => (

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -256,7 +256,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
       />
 
       {!hideSubjectNudge && subjects.length === 0 ? (
-        <div className="flex items-center justify-between gap-3 rounded-3xl border border-inverse/5 bg-card/40 p-4 text-sm text-fg/80 shadow-lg shadow-slate-900/30">
+        <div className="flex items-center justify-between gap-3 rounded-3xl border border-inverse/5 bg-card/40 p-4 text-sm text-fg/80">
           <div className="flex items-center gap-3">
             <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-accent/15 text-accent">
               <Info className="h-4 w-4" />
@@ -342,7 +342,7 @@ const ProgressTodayModule = ({
   const summaryText = `${completed}/${safeTotal} reviews completed • ${safePercent}% complete. Keep up the rhythm — every checkmark keeps your memory sharp.`;
 
   return (
-    <section className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-accent/25 via-accent/20 to-transparent px-6 py-8 text-fg shadow-xl shadow-slate-950/30 md:px-8">
+    <section className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-accent/25 via-accent/20 to-transparent px-6 py-8 text-fg md:px-8">
       <div
         className="absolute inset-y-0 right-0 h-full w-1/2 bg-[radial-gradient(circle_at_top,_hsl(var(--bg)_/_0.35),_transparent_65%)]"
         aria-hidden="true"
@@ -414,7 +414,7 @@ const PersonalizedReviewPlanModule = ({
   const nextDateLabel = nextTopic ? formatDateWithWeekday(nextTopic.nextReviewDate) : null;
 
   return (
-    <section className="rounded-3xl border border-inverse/10 bg-bg/60 px-6 py-6 shadow-lg shadow-slate-950/30 backdrop-blur md:px-8">
+    <section className="rounded-3xl border border-inverse/10 bg-bg/60 px-6 py-6 backdrop-blur md:px-8">
       <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
         <div className="space-y-4 lg:flex-1">
           <div className="space-y-3">

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -256,14 +256,14 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
       />
 
       {!hideSubjectNudge && subjects.length === 0 ? (
-        <div className="flex items-center justify-between gap-3 rounded-3xl border border-white/5 bg-slate-900/40 p-4 text-sm text-zinc-200 shadow-lg shadow-slate-900/30">
+        <div className="flex items-center justify-between gap-3 rounded-3xl border border-inverse/5 bg-card/40 p-4 text-sm text-fg/80 shadow-lg shadow-slate-900/30">
           <div className="flex items-center gap-3">
             <span className="flex h-9 w-9 items-center justify-center rounded-2xl bg-accent/15 text-accent">
               <Info className="h-4 w-4" />
             </span>
             <div className="space-y-1">
-              <p className="font-medium text-white">Manage subjects and exam dates in the Subjects tab.</p>
-              <p className="text-xs text-zinc-400">Organise your subjects to align topics with upcoming exams.</p>
+              <p className="font-medium text-fg">Manage subjects and exam dates in the Subjects tab.</p>
+              <p className="text-xs text-muted-foreground">Organise your subjects to align topics with upcoming exams.</p>
             </div>
           </div>
           <div className="flex items-center gap-2">
@@ -274,7 +274,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
               type="button"
               size="icon"
               variant="ghost"
-              className="rounded-full text-zinc-400 hover:text-white"
+              className="rounded-full text-muted-foreground hover:text-fg"
               onClick={() => setHideSubjectNudge(true)}
               aria-label="Dismiss"
             >
@@ -316,12 +316,12 @@ const StatPill = ({
   icon: LucideIcon;
   tone: string;
 }) => (
-  <div className="flex items-center justify-between gap-3 rounded-2xl border border-white/5 bg-white/5 px-4 py-3">
+  <div className="flex items-center justify-between gap-3 rounded-2xl border border-inverse/5 bg-inverse/5 px-4 py-3">
     <div className="space-y-0.5">
-      <p className="text-xs font-medium uppercase tracking-wide text-zinc-400">{label}</p>
-      <p className="text-lg font-semibold text-white">{value}</p>
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="text-lg font-semibold text-fg">{value}</p>
     </div>
-    <span className={`rounded-xl bg-slate-900/60 p-2 ${tone}`}>
+    <span className={`rounded-xl bg-card/60 p-2 ${tone}`}>
       <Icon className="h-5 w-5" />
     </span>
   </div>
@@ -342,8 +342,11 @@ const ProgressTodayModule = ({
   const summaryText = `${completed}/${safeTotal} reviews completed • ${safePercent}% complete. Keep up the rhythm — every checkmark keeps your memory sharp.`;
 
   return (
-    <section className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-accent/25 via-accent/20 to-transparent px-6 py-8 text-white shadow-xl shadow-slate-950/30 md:px-8">
-      <div className="absolute inset-y-0 right-0 h-full w-1/2 bg-[radial-gradient(circle_at_top,_rgba(15,23,42,0.35),_transparent_65%)]" aria-hidden="true" />
+    <section className="relative overflow-hidden rounded-3xl bg-gradient-to-r from-accent/25 via-accent/20 to-transparent px-6 py-8 text-fg shadow-xl shadow-slate-950/30 md:px-8">
+      <div
+        className="absolute inset-y-0 right-0 h-full w-1/2 bg-[radial-gradient(circle_at_top,_hsl(var(--bg)_/_0.35),_transparent_65%)]"
+        aria-hidden="true"
+      />
       <div className="relative flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
         <div className="space-y-4 md:max-w-xl">
           <div className="space-y-1">
@@ -351,21 +354,21 @@ const ProgressTodayModule = ({
             <h2 className="text-3xl font-semibold">
               {completed}/{safeTotal} reviews completed
             </h2>
-            <p className="text-sm text-white/70">{summaryText}</p>
+            <p className="text-sm text-fg/70">{summaryText}</p>
           </div>
-          <div className="space-y-3 text-sm text-white/80">
-            <div className="h-2 w-full overflow-hidden rounded-full bg-white/20">
+          <div className="space-y-3 text-sm text-fg/80">
+            <div className="h-2 w-full overflow-hidden rounded-full bg-inverse/20">
               <div
-                className="h-full rounded-full bg-white/90 transition-all"
+                className="h-full rounded-full bg-inverse/90 transition-all"
                 style={{ width: `${safePercent}%` }}
                 aria-hidden="true"
               />
             </div>
             <div className="flex flex-wrap items-center gap-3 font-medium">
-              <span className="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-wide text-white/80">
+              <span className="rounded-full bg-inverse/15 px-3 py-1 text-xs uppercase tracking-wide text-fg/80">
                 {safePercent}% complete
               </span>
-              <span className={isComplete ? "text-emerald-200" : "text-sky-100"}>
+              <span className={isComplete ? "text-success/20" : "text-accent/20"}>
                 {isComplete
                   ? "Great work! You’ve completed today’s reviews."
                   : "Finish today to extend your streak."}
@@ -373,14 +376,14 @@ const ProgressTodayModule = ({
             </div>
           </div>
         </div>
-        <dl className="grid gap-3 text-sm text-white/80 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2">
-          <div className="rounded-2xl border border-white/15 bg-slate-950/30 px-4 py-3 backdrop-blur">
-            <dt className="text-xs uppercase tracking-wide text-white/50">Completed</dt>
-            <dd className="text-lg font-semibold text-white">{completed}</dd>
+        <dl className="grid gap-3 text-sm text-fg/80 sm:grid-cols-2 md:grid-cols-1 lg:grid-cols-2">
+          <div className="rounded-2xl border border-inverse/15 bg-bg/30 px-4 py-3 backdrop-blur">
+            <dt className="text-xs uppercase tracking-wide text-fg/50">Completed</dt>
+            <dd className="text-lg font-semibold text-fg">{completed}</dd>
           </div>
-          <div className="rounded-2xl border border-white/15 bg-slate-950/30 px-4 py-3 backdrop-blur">
-            <dt className="text-xs uppercase tracking-wide text-white/50">Remaining</dt>
-            <dd className="text-lg font-semibold text-white">{Math.max(safeTotal - completed, 0)}</dd>
+          <div className="rounded-2xl border border-inverse/15 bg-bg/30 px-4 py-3 backdrop-blur">
+            <dt className="text-xs uppercase tracking-wide text-fg/50">Remaining</dt>
+            <dd className="text-lg font-semibold text-fg">{Math.max(safeTotal - completed, 0)}</dd>
           </div>
         </dl>
       </div>
@@ -411,7 +414,7 @@ const PersonalizedReviewPlanModule = ({
   const nextDateLabel = nextTopic ? formatDateWithWeekday(nextTopic.nextReviewDate) : null;
 
   return (
-    <section className="rounded-3xl border border-white/10 bg-slate-950/60 px-6 py-6 shadow-lg shadow-slate-950/30 backdrop-blur md:px-8">
+    <section className="rounded-3xl border border-inverse/10 bg-bg/60 px-6 py-6 shadow-lg shadow-slate-950/30 backdrop-blur md:px-8">
       <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
         <div className="space-y-4 lg:flex-1">
           <div className="space-y-3">
@@ -419,33 +422,33 @@ const PersonalizedReviewPlanModule = ({
               Personalized review plan
             </span>
             <div className="space-y-2">
-              <h2 className="text-2xl font-semibold text-white">Your next five minutes matter.</h2>
-              <p className="text-sm text-zinc-300">
+              <h2 className="text-2xl font-semibold text-fg">Your next five minutes matter.</h2>
+              <p className="text-sm text-muted-foreground">
                 {dueCount === 0
                   ? "Great work! You’ve completed today’s reviews. Here’s what’s coming next."
                   : `You have ${dueCount} topic${dueCount === 1 ? "" : "s"} ready for review. Finish them to extend your streak.`}
               </p>
               {nextTopic ? (
-                <p className="text-xs text-zinc-400">
-                  Next up: <span className="font-semibold text-zinc-100">{nextTopic.title}</span> • {nextRelative} ({nextDateLabel})
+                <p className="text-xs text-muted-foreground">
+                  Next up: <span className="font-semibold text-inverse">{nextTopic.title}</span> • {nextRelative} ({nextDateLabel})
                 </p>
               ) : (
-                <p className="text-xs text-zinc-400">You’re all caught up. Check back tomorrow or add a topic.</p>
+                <p className="text-xs text-muted-foreground">You’re all caught up. Check back tomorrow or add a topic.</p>
               )}
             </div>
           </div>
           {overloadWarning ? (
-            <div className="rounded-2xl border border-amber-400/40 bg-amber-500/10 px-4 py-2 text-sm text-amber-100">
+            <div className="rounded-2xl border border-warn/40 bg-warn/10 px-4 py-2 text-sm text-warn/20">
               {overloadWarning}
             </div>
           ) : null}
         </div>
 
-        <div className="grid flex-1 gap-3 text-white/90 sm:grid-cols-2 lg:grid-cols-[repeat(3,minmax(0,1fr))_auto] lg:gap-4">
-          <StatPill label="Due today" value={dueCount} icon={Flame} tone="text-rose-200" />
-          <StatPill label="Upcoming" value={upcomingCount} icon={CalendarClock} tone="text-amber-200" />
-          <StatPill label="Streak" value={`${streak} day${streak === 1 ? "" : "s"}`} icon={Trophy} tone="text-emerald-200" />
-          <div className="flex min-w-[14rem] flex-col gap-2 rounded-2xl border border-white/10 bg-slate-900/80 p-4">
+        <div className="grid flex-1 gap-3 text-fg/90 sm:grid-cols-2 lg:grid-cols-[repeat(3,minmax(0,1fr))_auto] lg:gap-4">
+          <StatPill label="Due today" value={dueCount} icon={Flame} tone="text-error/20" />
+          <StatPill label="Upcoming" value={upcomingCount} icon={CalendarClock} tone="text-warn/30" />
+          <StatPill label="Streak" value={`${streak} day${streak === 1 ? "" : "s"}`} icon={Trophy} tone="text-success/20" />
+          <div className="flex min-w-[14rem] flex-col gap-2 rounded-2xl border border-inverse/10 bg-card/80 p-4">
             <Button onClick={onAddTopic} size="sm" className="gap-2 rounded-full">
               <Plus className="h-4 w-4" /> Add topic
             </Button>
@@ -457,7 +460,7 @@ const PersonalizedReviewPlanModule = ({
                 onFocusDue();
               }}
               disabled={dueCount === 0}
-              className="gap-2 rounded-full border-white/20 text-white disabled:opacity-40"
+              className="gap-2 rounded-full border-inverse/20 text-fg disabled:opacity-40"
             >
               <Flame className="h-4 w-4" /> Due reviews ({dueCount})
             </Button>

--- a/src/components/dashboard/quick-revision-dialog.tsx
+++ b/src/components/dashboard/quick-revision-dialog.tsx
@@ -158,7 +158,7 @@ export function QuickRevisionDialog({
         aria-modal="true"
         aria-labelledby="quick-revision-title"
         aria-describedby="quick-revision-description"
-        className="relative w-full max-w-md max-h-[calc(100vh-3rem)] overflow-y-auto rounded-3xl border border-inverse/10 bg-card/95 p-6 text-fg shadow-2xl outline-none sm:max-h-[min(520px,calc(100vh-6rem))] sm:p-8"
+        className="relative w-full max-w-md max-h-[calc(100vh-3rem)] overflow-y-auto rounded-3xl border border-inverse/10 bg-card/95 p-6 text-fg outline-none sm:max-h-[min(520px,calc(100vh-6rem))] sm:p-8"
         tabIndex={-1}
       >
         <button

--- a/src/components/dashboard/quick-revision-dialog.tsx
+++ b/src/components/dashboard/quick-revision-dialog.tsx
@@ -144,7 +144,7 @@ export function QuickRevisionDialog({
   const overlay = (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-[1000] flex items-end justify-center bg-slate-950/80 px-4 pb-[max(env(safe-area-inset-bottom),16px)] pt-[max(env(safe-area-inset-top),24px)] backdrop-blur-sm transition sm:items-center sm:pb-6"
+      className="fixed inset-0 z-[1000] flex items-end justify-center bg-bg/80 px-4 pb-[max(env(safe-area-inset-bottom),16px)] pt-[max(env(safe-area-inset-top),24px)] backdrop-blur-sm transition sm:items-center sm:pb-6"
       role="presentation"
       onMouseDown={(event) => {
         if (event.target === overlayRef.current) {
@@ -158,34 +158,34 @@ export function QuickRevisionDialog({
         aria-modal="true"
         aria-labelledby="quick-revision-title"
         aria-describedby="quick-revision-description"
-        className="relative w-full max-w-md max-h-[calc(100vh-3rem)] overflow-y-auto rounded-3xl border border-white/10 bg-slate-900/95 p-6 text-white shadow-2xl outline-none sm:max-h-[min(520px,calc(100vh-6rem))] sm:p-8"
+        className="relative w-full max-w-md max-h-[calc(100vh-3rem)] overflow-y-auto rounded-3xl border border-inverse/10 bg-card/95 p-6 text-fg shadow-2xl outline-none sm:max-h-[min(520px,calc(100vh-6rem))] sm:p-8"
         tabIndex={-1}
       >
         <button
           type="button"
-          className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 text-zinc-300 transition hover:text-white"
+          className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full border border-inverse/10 text-muted-foreground transition hover:text-fg"
           onClick={onClose}
           aria-label="Close quick revision dialog"
         >
           <X className="h-4 w-4" />
         </button>
         <div className="space-y-3 pr-8">
-          <div className="inline-flex items-center gap-2 rounded-full bg-emerald-500/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-emerald-200">
+          <div className="inline-flex items-center gap-2 rounded-full bg-success/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-success/20">
             Quick revision
           </div>
-          <h2 id="quick-revision-title" className="text-xl font-semibold text-white">
+          <h2 id="quick-revision-title" className="text-xl font-semibold text-fg">
             Quick revision
           </h2>
-          <p id="quick-revision-description" className="text-sm text-zinc-300">
+          <p id="quick-revision-description" className="text-sm text-muted-foreground">
             {topicTitle ? (
               <>
-                Record today’s revision for <span className="font-semibold text-white">{topicTitle}</span>. We’ll keep your scheduled reviews intact.
+                Record today’s revision for <span className="font-semibold text-fg">{topicTitle}</span>. We’ll keep your scheduled reviews intact.
               </>
             ) : (
               "Record today’s revision without changing your upcoming schedule."
             )}
           </p>
-          <p className="text-xs text-zinc-400">
+          <p className="text-xs text-muted-foreground">
             You can log one quick revision per topic each day. Use it when you squeeze in extra practice.
           </p>
         </div>
@@ -202,7 +202,7 @@ export function QuickRevisionDialog({
             type="button"
             onClick={onConfirm}
             disabled={isConfirming}
-            className="w-full rounded-2xl bg-emerald-500/80 text-slate-950 transition hover:bg-emerald-400 sm:w-auto"
+            className="w-full rounded-2xl bg-success/80 text-inverse-foreground transition hover:bg-success sm:w-auto"
           >
             Log revision
           </Button>

--- a/src/components/dashboard/topic-card.tsx
+++ b/src/components/dashboard/topic-card.tsx
@@ -368,22 +368,19 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
     due: {
       label: "Due now",
       helper: `${formatRelativeToNow(topic.nextReviewDate)} • ${formatDateWithWeekday(topic.nextReviewDate)}`,
-      className:
-        "border border-error/20 bg-error/15 text-error/20 shadow-[0_1px_10px_hsl(var(--error)_/_0.15)]",
+      className: "border border-error/20 bg-error/15 text-error/20",
       icon: <Flame className="h-4 w-4" />
     },
     upcoming: {
       label: "Upcoming",
       helper: `${formatRelativeToNow(topic.nextReviewDate)} • ${formatDateWithWeekday(topic.nextReviewDate)}`,
-      className:
-        "border border-accent/20 bg-accent/15 text-accent/20 shadow-[0_1px_10px_hsl(var(--accent)_/_0.12)]",
+      className: "border border-accent/20 bg-accent/15 text-accent/20",
       icon: <CalendarClock className="h-4 w-4" />
     },
     completed: {
       label: "Completed",
       helper: `Reviewed today • Next ${formatDateWithWeekday(topic.nextReviewDate)}`,
-      className:
-        "border border-success/20 bg-success/15 text-success/20 shadow-[0_1px_10px_hsl(var(--success)_/_0.12)]",
+      className: "border border-success/20 bg-success/15 text-success/20",
       icon: <CheckCircle2 className="h-4 w-4" />
     }
   };
@@ -436,13 +433,13 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
       <motion.article
         layout
         transition={{ type: "spring", stiffness: 260, damping: 26 }}
-        className="group relative flex h-full flex-col justify-between rounded-3xl border border-inverse/5 bg-card/40 p-6 shadow-lg shadow-slate-900/30 backdrop-blur-xl"
+        className="group relative flex h-full flex-col justify-between rounded-3xl border border-inverse/5 bg-card/40 p-6 backdrop-blur-xl"
       >
         <div className="space-y-4">
           <div className="flex items-start justify-between gap-3">
             <div className="flex items-start gap-3">
               <span
-                className="flex h-12 w-12 items-center justify-center rounded-2xl shadow-inner"
+                className="flex h-12 w-12 items-center justify-center rounded-2xl"
                 style={{ backgroundColor: `${identityColor}1f` }}
               >
                 <IconPreview name={identityIcon} className="h-5 w-5" />
@@ -753,7 +750,7 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.9, opacity: 0 }}
             transition={{ type: "spring", stiffness: 260, damping: 26 }}
-            className="w-full max-w-md rounded-3xl border border-inverse/10 bg-card/90 p-6 shadow-2xl"
+            className="w-full max-w-md rounded-3xl border border-inverse/10 bg-card/90 p-6"
           >
             <div className="flex items-start gap-3">
               {icon ? <span className="mt-1 rounded-2xl bg-inverse/10 p-2 text-accent">{icon}</span> : null}

--- a/src/components/dashboard/topic-card.tsx
+++ b/src/components/dashboard/topic-card.tsx
@@ -30,6 +30,7 @@ import {
   nowInTimeZone
 } from "@/lib/date";
 import { cn } from "@/lib/utils";
+import { FALLBACK_SUBJECT_COLOR } from "@/lib/colors";
 import { REMINDER_TIME_OPTIONS, REVISE_LOCKED_MESSAGE } from "@/lib/constants";
 import {
   AlertTriangle,
@@ -84,7 +85,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
   );
 
   const identityIcon = subject?.icon ?? "Sparkles";
-  const identityColor = subject?.color ?? "#38bdf8";
+  const identityColor = subject?.color ?? FALLBACK_SUBJECT_COLOR;
 
   const [notesValue, setNotesValue] = React.useState(topic.notes ?? "");
   const [reminderValue, setReminderValue] = React.useState<ReminderValue>(() => {
@@ -368,21 +369,21 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
       label: "Due now",
       helper: `${formatRelativeToNow(topic.nextReviewDate)} • ${formatDateWithWeekday(topic.nextReviewDate)}`,
       className:
-        "border border-rose-400/20 bg-rose-500/15 text-rose-100 shadow-[0_1px_10px_rgba(244,63,94,0.15)]",
+        "border border-error/20 bg-error/15 text-error/20 shadow-[0_1px_10px_hsl(var(--error)_/_0.15)]",
       icon: <Flame className="h-4 w-4" />
     },
     upcoming: {
       label: "Upcoming",
       helper: `${formatRelativeToNow(topic.nextReviewDate)} • ${formatDateWithWeekday(topic.nextReviewDate)}`,
       className:
-        "border border-sky-400/20 bg-sky-500/15 text-sky-100 shadow-[0_1px_10px_rgba(14,165,233,0.12)]",
+        "border border-accent/20 bg-accent/15 text-accent/20 shadow-[0_1px_10px_hsl(var(--accent)_/_0.12)]",
       icon: <CalendarClock className="h-4 w-4" />
     },
     completed: {
       label: "Completed",
       helper: `Reviewed today • Next ${formatDateWithWeekday(topic.nextReviewDate)}`,
       className:
-        "border border-emerald-400/20 bg-emerald-500/15 text-emerald-100 shadow-[0_1px_10px_rgba(16,185,129,0.12)]",
+        "border border-success/20 bg-success/15 text-success/20 shadow-[0_1px_10px_hsl(var(--success)_/_0.12)]",
       icon: <CheckCircle2 className="h-4 w-4" />
     }
   };
@@ -397,32 +398,32 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
   };
 
   const ReminderStatus = () => (
-    <div className="flex flex-col gap-1 rounded-2xl border border-white/10 bg-slate-900/50 p-3">
-      <div className="flex items-center justify-between text-xs text-zinc-400">
-        <span className="inline-flex items-center gap-1 text-zinc-300">
+    <div className="flex flex-col gap-1 rounded-2xl border border-inverse/10 bg-card/50 p-3">
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span className="inline-flex items-center gap-1 text-muted-foreground">
           <Clock8 className="h-3.5 w-3.5" /> Interval
         </span>
-        <span className="text-zinc-100">
+        <span className="text-inverse">
           {currentInterval} day{currentInterval === 1 ? "" : "s"}
         </span>
       </div>
-      <div className="h-2 rounded-full bg-slate-800">
+      <div className="h-2 rounded-full bg-muted">
         <motion.div
           layout
           className="h-full rounded-full bg-accent"
           style={{ width: `${Math.min(progress, 100)}%` }}
         />
       </div>
-      <div className="flex items-center justify-between text-xs text-zinc-400">
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span>
-          <span className="font-medium text-zinc-200">{clampedIndex + 1}</span> of {totalIntervals} steps
+          <span className="font-medium text-fg/80">{clampedIndex + 1}</span> of {totalIntervals} steps
         </span>
         {reviewedToday ? (
-          <span className="inline-flex items-center gap-1 text-emerald-300">
+          <span className="inline-flex items-center gap-1 text-success/40">
             <CheckCircle2 className="h-3.5 w-3.5" /> Completed today
           </span>
         ) : (
-          <span className="inline-flex items-center gap-1 text-sky-300">
+          <span className="inline-flex items-center gap-1 text-accent/30">
             <Sparkles className="h-3.5 w-3.5" /> Keep the momentum
           </span>
         )}
@@ -435,7 +436,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
       <motion.article
         layout
         transition={{ type: "spring", stiffness: 260, damping: 26 }}
-        className="group relative flex h-full flex-col justify-between rounded-3xl border border-white/5 bg-slate-900/40 p-6 shadow-lg shadow-slate-900/30 backdrop-blur-xl"
+        className="group relative flex h-full flex-col justify-between rounded-3xl border border-inverse/5 bg-card/40 p-6 shadow-lg shadow-slate-900/30 backdrop-blur-xl"
       >
         <div className="space-y-4">
           <div className="flex items-start justify-between gap-3">
@@ -447,15 +448,15 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
                 <IconPreview name={identityIcon} className="h-5 w-5" />
               </span>
               <div className="space-y-1.5">
-                <h3 className="text-lg font-semibold text-white">{topic.title}</h3>
+                <h3 className="text-lg font-semibold text-fg">{topic.title}</h3>
                 {topic.categoryLabel ? (
-                  <span className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-zinc-100">
+                  <span className="inline-flex items-center gap-2 rounded-full bg-inverse/10 px-3 py-1 text-xs font-medium text-inverse">
                     <span className="h-2 w-2 rounded-full" style={{ backgroundColor: identityColor }} />
                     {topic.categoryLabel}
                   </span>
                 ) : null}
                 {examDateLabel ? (
-                  <span className="inline-flex items-center gap-2 rounded-full bg-amber-500/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-amber-100">
+                  <span className="inline-flex items-center gap-2 rounded-full bg-warn/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-warn/20">
                     <CalendarClock className="h-3.5 w-3.5" /> Exam {examDateLabel}
                   </span>
                 ) : null}
@@ -471,12 +472,12 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
                 {statusStyles[currentStatus].icon}
                 {statusStyles[currentStatus].label}
               </span>
-              <p className="text-[11px] font-medium uppercase tracking-wide text-zinc-400">Next review</p>
-              <p className="text-sm font-semibold text-white/90">
+              <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">Next review</p>
+              <p className="text-sm font-semibold text-fg/90">
                 {formatDateWithWeekday(topic.nextReviewDate)}
               </p>
-              <p className="text-xs text-zinc-400">{statusStyles[currentStatus].helper}</p>
-              <p className="text-[11px] text-zinc-500">
+              <p className="text-xs text-muted-foreground">{statusStyles[currentStatus].helper}</p>
+              <p className="text-[11px] text-muted-foreground/80">
                 Retention target ≈ {Math.round(topic.retrievabilityTarget * 100)}%
               </p>
             </div>
@@ -484,15 +485,15 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
 
           <ReminderStatus />
 
-          <div className="grid gap-3 rounded-2xl border border-white/10 bg-white/5 p-3">
-            <label className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-zinc-400">
-              <span className="inline-flex items-center gap-1 text-zinc-300">
+          <div className="grid gap-3 rounded-2xl border border-inverse/10 bg-inverse/5 p-3">
+            <label className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <span className="inline-flex items-center gap-1 text-muted-foreground">
                 <Bell className="h-3.5 w-3.5" /> Reminder
               </span>
-              {isSavingReminder ? <span className="text-[10px] text-zinc-500">Saving…</span> : null}
+              {isSavingReminder ? <span className="text-[10px] text-muted-foreground/80">Saving…</span> : null}
             </label>
             <Select value={reminderValue} onValueChange={handleReminderChange}>
-              <SelectTrigger className="h-10 rounded-xl border-white/10 bg-slate-900/60 text-sm">
+              <SelectTrigger className="h-10 rounded-xl border-inverse/10 bg-card/60 text-sm">
                 <SelectValue placeholder="Choose reminder" />
               </SelectTrigger>
               <SelectContent className="rounded-2xl backdrop-blur">
@@ -519,7 +520,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
                     value={customTime}
                     onChange={(event) => setCustomTime(event.target.value)}
                     onBlur={handleCustomTimeCommit}
-                    className="h-10 w-32 rounded-xl border-white/10 bg-slate-900/60 text-sm"
+                    className="h-10 w-32 rounded-xl border-inverse/10 bg-card/60 text-sm"
                   />
                   <Button type="button" size="sm" variant="outline" onClick={handleCustomTimeCommit}>
                     Save time
@@ -527,15 +528,15 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
                 </motion.div>
               ) : null}
             </AnimatePresence>
-            <p className="text-xs text-zinc-400">{formatTime(topic.reminderTime)}</p>
+            <p className="text-xs text-muted-foreground">{formatTime(topic.reminderTime)}</p>
           </div>
 
           <div className="space-y-2">
-            <label className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-zinc-400">
-              <span className="inline-flex items-center gap-1 text-zinc-300">
+            <label className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              <span className="inline-flex items-center gap-1 text-muted-foreground">
                 <PenLine className="h-3.5 w-3.5" /> Notes
               </span>
-              {isSavingNotes ? <span className="text-[10px] text-zinc-500">Saving…</span> : null}
+              {isSavingNotes ? <span className="text-[10px] text-muted-foreground/80">Saving…</span> : null}
             </label>
             <Textarea
               value={notesValue}
@@ -543,19 +544,19 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
               onBlur={handleNotesBlur}
               placeholder="Add a quick note or mnemonic to help you remember!"
               rows={4}
-              className="min-h-[120px] rounded-2xl border-white/10 bg-slate-900/60 text-sm"
+              className="min-h-[120px] rounded-2xl border-inverse/10 bg-card/60 text-sm"
             />
           </div>
 
           <div className="space-y-2">
-            <label className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-zinc-400">
+            <label className="flex items-center gap-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
               <RefreshCw className="h-3.5 w-3.5" /> Schedule adjustments
             </label>
             <Select
               value={autoAdjustPreference}
               onValueChange={(value: AutoAdjustPreference) => handlePreferenceChange(value)}
             >
-              <SelectTrigger className="h-10 rounded-xl border-white/10 bg-slate-900/60 text-sm text-left">
+              <SelectTrigger className="h-10 rounded-xl border-inverse/10 bg-card/60 text-sm text-left">
                 <SelectValue placeholder="Choose behaviour" />
               </SelectTrigger>
               <SelectContent className="rounded-2xl backdrop-blur">
@@ -566,7 +567,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
                 ))}
               </SelectContent>
             </Select>
-            <p className="text-xs text-zinc-400">
+            <p className="text-xs text-muted-foreground">
               Tweak how upcoming reviews adapt when you study early.
             </p>
           </div>
@@ -590,7 +591,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
             <Button
               type="button"
               variant="outline"
-              className="min-w-[150px] gap-2 rounded-2xl border-amber-400/40 text-amber-100 hover:bg-amber-500/10"
+              className="min-w-[150px] gap-2 rounded-2xl border-warn/40 text-warn/20 hover:bg-warn/10"
               onClick={handleSkipToday}
             >
               <SkipForward className="h-4 w-4" /> Skip today
@@ -598,10 +599,10 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
           </div>
           {!due && hasUsedReviseToday ? (
             <div className="space-y-1 text-right text-xs sm:text-left">
-              <p className="font-medium text-emerald-300">Logged today’s revision.</p>
-              <p className="text-zinc-400">{nextAvailabilityMessage}</p>
+              <p className="font-medium text-success/40">Logged today’s revision.</p>
+              <p className="text-muted-foreground">{nextAvailabilityMessage}</p>
               {nextAvailabilitySubtext ? (
-                <p className="text-[11px] text-zinc-500">{nextAvailabilitySubtext}</p>
+                <p className="text-[11px] text-muted-foreground/80">{nextAvailabilitySubtext}</p>
               ) : null}
             </div>
           ) : null}
@@ -610,7 +611,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
               type="button"
               variant="ghost"
               size="icon"
-              className="rounded-xl text-zinc-300 hover:text-white"
+              className="rounded-xl text-muted-foreground hover:text-fg"
               onClick={onEdit}
               aria-label="Edit topic"
             >
@@ -620,7 +621,7 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
               type="button"
               variant="ghost"
               size="icon"
-              className="rounded-xl text-zinc-300 hover:text-rose-200"
+              className="rounded-xl text-muted-foreground hover:text-error/20"
               onClick={handleDelete}
               aria-label="Remove topic"
             >
@@ -742,7 +743,7 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
     <AnimatePresence>
       {open ? (
         <motion.div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 backdrop-blur"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-bg/70 backdrop-blur"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
@@ -752,25 +753,25 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.9, opacity: 0 }}
             transition={{ type: "spring", stiffness: 260, damping: 26 }}
-            className="w-full max-w-md rounded-3xl border border-white/10 bg-slate-900/90 p-6 shadow-2xl"
+            className="w-full max-w-md rounded-3xl border border-inverse/10 bg-card/90 p-6 shadow-2xl"
           >
             <div className="flex items-start gap-3">
-              {icon ? <span className="mt-1 rounded-2xl bg-white/10 p-2 text-accent">{icon}</span> : null}
+              {icon ? <span className="mt-1 rounded-2xl bg-inverse/10 p-2 text-accent">{icon}</span> : null}
               <div className="space-y-2">
-                <h2 className="text-lg font-semibold text-white">{title}</h2>
-                <p className="text-sm text-zinc-300">{description}</p>
-                {warning ? <p className="text-xs font-semibold text-amber-200">{warning}</p> : null}
+                <h2 className="text-lg font-semibold text-fg">{title}</h2>
+                <p className="text-sm text-muted-foreground">{description}</p>
+                {warning ? <p className="text-xs font-semibold text-warn/30">{warning}</p> : null}
               </div>
             </div>
             {extraActions && extraActions.length > 0 ? (
-              <div className="mt-4 space-y-2 rounded-2xl border border-white/10 bg-white/5 p-3 text-xs text-zinc-300">
-                <p className="font-semibold text-white">Quick preferences</p>
+              <div className="mt-4 space-y-2 rounded-2xl border border-inverse/10 bg-inverse/5 p-3 text-xs text-muted-foreground">
+                <p className="font-semibold text-fg">Quick preferences</p>
                 {extraActions.map((action) => (
                   <button
                     key={action.label}
                     type="button"
                     onClick={action.action}
-                    className="w-full rounded-xl border border-white/10 px-3 py-2 text-left transition hover:border-accent/40 hover:text-accent"
+                    className="w-full rounded-xl border border-inverse/10 px-3 py-2 text-left transition hover:border-accent/40 hover:text-accent"
                   >
                     {action.label}
                   </button>
@@ -787,9 +788,9 @@ const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
                 className={cn(
                   "min-w-[140px] rounded-2xl",
                   confirmTone === "danger"
-                    ? "bg-rose-500/80 hover:bg-rose-500 text-white"
+                    ? "bg-error/80 hover:bg-error text-fg"
                     : confirmTone === "warning"
-                    ? "bg-amber-500/80 hover:bg-amber-500 text-slate-900"
+                    ? "bg-warn/80 hover:bg-warn text-inverse-foreground"
                     : ""
                 )}
               >

--- a/src/components/dashboard/topic-list.tsx
+++ b/src/components/dashboard/topic-list.tsx
@@ -385,7 +385,7 @@ export function TopicList({
   return (
     <div
       id={id}
-      className="rounded-[32px] border border-inverse/5 bg-card/50 p-5 shadow-xl shadow-slate-950/40 backdrop-blur xl:p-8"
+      className="rounded-[32px] border border-inverse/5 bg-card/50 p-5 backdrop-blur xl:p-8"
     >
       <div className="flex flex-col gap-5 xl:gap-6">
         <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:gap-8">
@@ -395,8 +395,8 @@ export function TopicList({
             </label>
             <div
               className={cn(
-                "group relative flex h-12 w-full min-w-0 items-center rounded-2xl border border-inverse/10 bg-bg/85 px-4 text-base text-fg shadow-lg shadow-slate-950/60 transition",
-                "hover:border-inverse/20 hover:shadow-xl hover:shadow-slate-950/70",
+                "group relative flex h-12 w-full min-w-0 items-center rounded-2xl border border-inverse/10 bg-bg/85 px-4 text-base text-fg transition",
+                "hover:border-inverse/20",
                 searchFocused
                   ? "border-accent ring-2 ring-accent/45 ring-offset-2 ring-offset-bg"
                   : "focus-within:border-accent focus-within:ring-2 focus-within:ring-accent/45 focus-within:ring-offset-2 focus-within:ring-offset-bg"
@@ -509,7 +509,7 @@ export function TopicList({
                   <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-72 rounded-2xl border border-inverse/10 bg-card/95 p-3 text-sm text-fg shadow-xl">
+              <PopoverContent className="w-72 rounded-2xl border border-inverse/10 bg-card/95 p-3 text-sm text-fg">
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Subjects</span>
                   <div className="flex items-center gap-2">

--- a/src/components/dashboard/topic-list.tsx
+++ b/src/components/dashboard/topic-list.tsx
@@ -37,6 +37,7 @@ import {
   nextStartOfDayInTimeZone
 } from "@/lib/date";
 import { cn } from "@/lib/utils";
+import { FALLBACK_SUBJECT_COLOR } from "@/lib/colors";
 import { REVISE_LOCKED_MESSAGE } from "@/lib/constants";
 import { toast } from "sonner";
 
@@ -68,20 +69,20 @@ const SORT_STORAGE_KEY = "dashboard-topic-sort";
 const STATUS_META: Record<TopicStatus, { label: string; tone: string; subtle: string; icon: React.ReactNode }> = {
   overdue: {
     label: "Overdue",
-    tone: "bg-rose-500/15 text-rose-200 border border-rose-400/20",
-    subtle: "text-rose-200",
+    tone: "bg-error/15 text-error/20 border border-error/20",
+    subtle: "text-error/20",
     icon: <Flame className="h-3.5 w-3.5" aria-hidden="true" />
   },
   "due-today": {
     label: "Due today",
-    tone: "bg-amber-500/15 text-amber-200 border border-amber-400/20",
-    subtle: "text-amber-200",
+    tone: "bg-warn/15 text-warn/30 border border-warn/20",
+    subtle: "text-warn/30",
     icon: <CalendarClock className="h-3.5 w-3.5" aria-hidden="true" />
   },
   upcoming: {
     label: "Upcoming",
-    tone: "bg-sky-500/15 text-sky-200 border border-sky-400/20",
-    subtle: "text-sky-200",
+    tone: "bg-accent/15 text-accent/20 border border-accent/20",
+    subtle: "text-accent/20",
     icon: <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
   }
 };
@@ -263,7 +264,7 @@ export function TopicList({
       options.push({
         id: NO_SUBJECT_KEY,
         name: "No subject",
-        color: "#64748b",
+        color: FALLBACK_SUBJECT_COLOR,
         count: noSubjectCount
       });
     }
@@ -384,7 +385,7 @@ export function TopicList({
   return (
     <div
       id={id}
-      className="rounded-[32px] border border-white/5 bg-slate-900/50 p-5 shadow-xl shadow-slate-950/40 backdrop-blur xl:p-8"
+      className="rounded-[32px] border border-inverse/5 bg-card/50 p-5 shadow-xl shadow-slate-950/40 backdrop-blur xl:p-8"
     >
       <div className="flex flex-col gap-5 xl:gap-6">
         <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:gap-8">
@@ -394,15 +395,15 @@ export function TopicList({
             </label>
             <div
               className={cn(
-                "group relative flex h-12 w-full min-w-0 items-center rounded-2xl border border-white/10 bg-slate-950/85 px-4 text-base text-white shadow-lg shadow-slate-950/60 transition",
-                "hover:border-white/20 hover:shadow-xl hover:shadow-slate-950/70",
+                "group relative flex h-12 w-full min-w-0 items-center rounded-2xl border border-inverse/10 bg-bg/85 px-4 text-base text-fg shadow-lg shadow-slate-950/60 transition",
+                "hover:border-inverse/20 hover:shadow-xl hover:shadow-slate-950/70",
                 searchFocused
-                  ? "border-accent ring-2 ring-accent/45 ring-offset-2 ring-offset-slate-950"
-                  : "focus-within:border-accent focus-within:ring-2 focus-within:ring-accent/45 focus-within:ring-offset-2 focus-within:ring-offset-slate-950"
+                  ? "border-accent ring-2 ring-accent/45 ring-offset-2 ring-offset-bg"
+                  : "focus-within:border-accent focus-within:ring-2 focus-within:ring-accent/45 focus-within:ring-offset-2 focus-within:ring-offset-bg"
               )}
             >
               <Search
-                className="pointer-events-none absolute left-4 h-5 w-5 flex-none text-zinc-400"
+                className="pointer-events-none absolute left-4 h-5 w-5 flex-none text-muted-foreground"
                 aria-hidden="true"
               />
               <input
@@ -424,7 +425,7 @@ export function TopicList({
                   }
                 }}
                 placeholder="Search topics…"
-                className="h-full w-full rounded-2xl bg-transparent pl-10 pr-12 text-sm text-white placeholder:text-zinc-400 focus:outline-none"
+                className="h-full w-full rounded-2xl bg-transparent pl-10 pr-12 text-sm text-fg placeholder:text-muted-foreground focus:outline-none"
                 aria-describedby={filterDescriptions ? appliedFiltersDescriptionId : undefined}
                 autoComplete="off"
                 spellCheck={false}
@@ -440,8 +441,8 @@ export function TopicList({
                   handleClearSearch();
                 }}
                 className={cn(
-                  "absolute right-3 inline-flex h-7 w-7 flex-none items-center justify-center rounded-full text-zinc-400 transition",
-                  "hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
+                  "absolute right-3 inline-flex h-7 w-7 flex-none items-center justify-center rounded-full text-muted-foreground transition",
+                  "hover:text-fg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
                   searchInput ? "opacity-100" : "pointer-events-none opacity-0"
                 )}
               >
@@ -453,15 +454,15 @@ export function TopicList({
                 Active filters: {filterDescriptions}
               </span>
             ) : null}
-            <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-zinc-500">
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground/80">
               <p className="flex items-center gap-1">
-                <span className="rounded-full border border-white/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-zinc-400">
+                <span className="rounded-full border border-inverse/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
                   /
                 </span>
                 to focus search
               </p>
               <p className="flex items-center gap-1">
-                <span className="rounded-full border border-white/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-zinc-400">
+                <span className="rounded-full border border-inverse/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
                   Esc
                 </span>
                 clears
@@ -469,9 +470,9 @@ export function TopicList({
             </div>
           </div>
 
-          <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400 xl:flex-nowrap xl:justify-end xl:gap-3">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground xl:flex-nowrap xl:justify-end xl:gap-3">
             <div
-              className="flex items-center gap-1 rounded-full border border-white/10 bg-slate-900/60 p-1"
+              className="flex items-center gap-1 rounded-full border border-inverse/10 bg-card/60 p-1"
               role="group"
               aria-label="Filter by status"
             >
@@ -486,8 +487,8 @@ export function TopicList({
                   className={cn(
                     "rounded-full px-3 py-1 text-xs transition",
                     statusFilter === value
-                      ? "bg-accent text-slate-950 hover:bg-accent/90"
-                      : "text-zinc-300 hover:text-white"
+                      ? "bg-accent text-inverse-foreground hover:bg-accent/90"
+                      : "text-muted-foreground hover:text-fg"
                   )}
                 >
                   {label}
@@ -501,16 +502,16 @@ export function TopicList({
                   type="button"
                   variant="outline"
                   size="sm"
-                  className="inline-flex items-center gap-2 rounded-full border-white/15 bg-slate-900/60 px-3 py-1 text-xs text-zinc-200 hover:border-white/25 hover:text-white"
+                  className="inline-flex items-center gap-2 rounded-full border-inverse/15 bg-card/60 px-3 py-1 text-xs text-fg/80 hover:border-inverse/25 hover:text-fg"
                 >
                   <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
                   {subjectsLabel}
-                  <ChevronDown className="h-3 w-3 text-zinc-400" aria-hidden="true" />
+                  <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-72 rounded-2xl border border-white/10 bg-slate-900/95 p-3 text-sm text-white shadow-xl">
+              <PopoverContent className="w-72 rounded-2xl border border-inverse/10 bg-card/95 p-3 text-sm text-fg shadow-xl">
                 <div className="flex items-center justify-between gap-2">
-                  <span className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Subjects</span>
+                  <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Subjects</span>
                   <div className="flex items-center gap-2">
                     <button
                       type="button"
@@ -524,7 +525,7 @@ export function TopicList({
                     </button>
                     <button
                       type="button"
-                      className="text-xs font-medium text-zinc-300 hover:underline"
+                      className="text-xs font-medium text-muted-foreground hover:underline"
                       onClick={() => onSubjectFilterChange(new Set<string>())}
                     >
                       Clear all
@@ -536,22 +537,22 @@ export function TopicList({
                     Search subjects
                   </label>
                   <div className="relative">
-                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500" aria-hidden="true" />
+                    <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/80" aria-hidden="true" />
                     <Input
                       id="subject-filter-search"
                       type="search"
                       value={subjectSearch}
                       onChange={(event) => setSubjectSearch(event.target.value)}
                       placeholder="Search subjects"
-                      className="h-9 w-full rounded-xl border-white/10 bg-slate-950/80 pl-9 pr-3 text-xs text-white placeholder:text-zinc-500 focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent/40"
+                      className="h-9 w-full rounded-xl border-inverse/10 bg-bg/80 pl-9 pr-3 text-xs text-fg placeholder:text-muted-foreground/80 focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent/40"
                     />
                   </div>
                 </div>
                 <div className="mt-3 max-h-64 space-y-1 overflow-y-auto">
                   {subjectOptions.length === 0 ? (
-                    <p className="text-xs text-zinc-400">No subjects yet.</p>
+                    <p className="text-xs text-muted-foreground">No subjects yet.</p>
                   ) : filteredSubjectOptions.length === 0 ? (
-                    <p className="text-xs text-zinc-400">No matching subjects.</p>
+                    <p className="text-xs text-muted-foreground">No matching subjects.</p>
                   ) : (
                     filteredSubjectOptions.map((option) => {
                       const isChecked = subjectFilter === null ? true : subjectFilter.has(option.id);
@@ -562,20 +563,20 @@ export function TopicList({
                           onClick={() => toggleSubject(option.id)}
                           role="menuitemcheckbox"
                           aria-checked={isChecked}
-                          className="flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm transition hover:bg-white/10"
+                          className="flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm transition hover:bg-inverse/10"
                         >
                           <span className="flex items-center gap-2">
                             <span className="flex h-2.5 w-2.5 rounded-full" style={{ backgroundColor: option.color }} />
                             {option.name}
                           </span>
-                          <span className="flex items-center gap-2 text-xs text-zinc-300">
+                          <span className="flex items-center gap-2 text-xs text-muted-foreground">
                             {option.count}
                             <span
                               className={cn(
                                 "flex h-5 w-5 items-center justify-center rounded-full border",
                                 isChecked
                                   ? "border-accent bg-accent/20 text-accent"
-                                  : "border-white/20 text-zinc-500"
+                                  : "border-inverse/20 text-muted-foreground/80"
                               )}
                             >
                               {isChecked ? <Check className="h-3 w-3" aria-hidden="true" /> : null}
@@ -595,12 +596,12 @@ export function TopicList({
                   type="button"
                   variant="outline"
                   size="sm"
-                  className="inline-flex items-center gap-2 rounded-full border-white/15 bg-slate-900/60 px-3 py-1 text-xs text-zinc-200 hover:border-white/25 hover:text-white"
+                  className="inline-flex items-center gap-2 rounded-full border-inverse/15 bg-card/60 px-3 py-1 text-xs text-fg/80 hover:border-inverse/25 hover:text-fg"
                 >
-                  <ChevronDown className="h-3 w-3 text-zinc-400" aria-hidden="true" /> Sort by: {sortLabels[sortOption]}
+                  <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" /> Sort by: {sortLabels[sortOption]}
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="w-56 rounded-2xl border border-white/10 bg-slate-900/95 p-2 text-sm text-white">
+              <PopoverContent className="w-56 rounded-2xl border border-inverse/10 bg-card/95 p-2 text-sm text-fg">
                 <div className="space-y-1">
                   {(Object.keys(sortLabels) as SortOption[]).map((value) => (
                     <button
@@ -612,7 +613,7 @@ export function TopicList({
                       }}
                       className={cn(
                         "flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left transition",
-                        sortOption === value ? "bg-accent/20 text-white" : "hover:bg-white/10 hover:text-white"
+                        sortOption === value ? "bg-accent/20 text-fg" : "hover:bg-inverse/10 hover:text-fg"
                       )}
                     >
                       <span>{sortLabels[value]}</span>
@@ -625,7 +626,7 @@ export function TopicList({
           </div>
         </div>
 
-        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-zinc-400" aria-live="polite">
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground" aria-live="polite">
           <span>
             Showing {totalFilteredCount} of {items.length} topics
             {totalHiddenCount > 0 ? ` • ${totalHiddenCount} hidden by filters` : ""}
@@ -634,7 +635,7 @@ export function TopicList({
             <button
               type="button"
               onClick={handleResetFilters}
-              className="rounded-full border border-white/10 px-3 py-1 text-[11px] uppercase tracking-wide text-zinc-300 transition hover:border-white/30 hover:text-white"
+              className="rounded-full border border-inverse/10 px-3 py-1 text-[11px] uppercase tracking-wide text-muted-foreground transition hover:border-inverse/30 hover:text-fg"
             >
               Clear filters
             </button>
@@ -643,21 +644,21 @@ export function TopicList({
 
         <div className="mt-2">
           {items.length === 0 ? (
-            <div className="flex h-72 flex-col items-center justify-center gap-4 rounded-3xl border border-white/5 bg-slate-950/40 p-10 text-center">
+            <div className="flex h-72 flex-col items-center justify-center gap-4 rounded-3xl border border-inverse/5 bg-bg/40 p-10 text-center">
               <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-accent/20 text-accent">
                 <Sparkles className="h-7 w-7" aria-hidden="true" />
               </div>
               <div className="space-y-2">
-                <h3 className="text-lg font-semibold text-white">No topics yet</h3>
-                <p className="text-sm text-zinc-400">Create your first topic to start reviewing.</p>
+                <h3 className="text-lg font-semibold text-fg">No topics yet</h3>
+                <p className="text-sm text-muted-foreground">Create your first topic to start reviewing.</p>
               </div>
               <Button onClick={onCreateTopic} className="gap-2 rounded-2xl">
                 <Sparkles className="h-4 w-4" aria-hidden="true" /> Add topic
               </Button>
             </div>
           ) : filteredItems.length === 0 ? (
-            <div className="flex h-60 flex-col items-center justify-center gap-4 rounded-3xl border border-white/5 bg-slate-950/40 p-10 text-center">
-              <p className="text-sm text-zinc-300">
+            <div className="flex h-60 flex-col items-center justify-center gap-4 rounded-3xl border border-inverse/5 bg-bg/40 p-10 text-center">
+              <p className="text-sm text-muted-foreground">
                 No topics match {searchQuery ? `‘${searchQuery}’` : "your current filters"}. Try clearing Subjects or changing the status.
               </p>
               <div className="flex flex-wrap justify-center gap-2">
@@ -666,7 +667,7 @@ export function TopicList({
                   variant="outline"
                   onClick={handleClearSearch}
                   disabled={!searchInput && !searchQuery}
-                  className="rounded-full border-white/20 bg-transparent px-4 py-2 text-sm text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 disabled:opacity-40"
+                  className="rounded-full border-inverse/20 bg-transparent px-4 py-2 text-sm text-fg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:opacity-40"
                 >
                   Clear search
                 </Button>
@@ -675,22 +676,22 @@ export function TopicList({
                   variant="outline"
                   onClick={handleResetFilters}
                   disabled={statusFilter === "all" && (subjectFilter === null || subjectFilter.size === totalSubjectOptions)}
-                  className="rounded-full border-white/20 bg-transparent px-4 py-2 text-sm text-white transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950 disabled:opacity-40"
+                  className="rounded-full border-inverse/20 bg-transparent px-4 py-2 text-sm text-fg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:opacity-40"
                 >
                   Reset filters
                 </Button>
               </div>
             </div>
           ) : (
-            <div className="overflow-hidden rounded-3xl border border-white/5 bg-slate-950/40">
-              <div className="hidden border-b border-white/5 px-6 py-3 text-xs font-semibold uppercase tracking-wide text-zinc-400 md:grid md:grid-cols-[minmax(0,2.5fr)_minmax(0,1.2fr)_minmax(0,1.3fr)_minmax(0,1fr)_auto]">
+            <div className="overflow-hidden rounded-3xl border border-inverse/5 bg-bg/40">
+              <div className="hidden border-b border-inverse/5 px-6 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid md:grid-cols-[minmax(0,2.5fr)_minmax(0,1.2fr)_minmax(0,1.3fr)_minmax(0,1fr)_auto]">
                 <span>Topic</span>
                 <span>Subject</span>
                 <span>Next review</span>
                 <span>Status</span>
                 <span className="text-right">Actions</span>
               </div>
-              <div className="divide-y divide-white/5">
+              <div className="divide-y divide-border/40">
                 {filteredItems.map((row) => (
                   <TopicListRow
                     key={row.topic.id}
@@ -902,7 +903,7 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
   const nextReviewRelativeLabel = formatRelativeToNow(item.topic.nextReviewDate);
 
   return (
-    <div className={cn("transition-colors", recentlyRevised ? "bg-emerald-500/10" : "bg-transparent")}
+    <div className={cn("transition-colors", recentlyRevised ? "bg-success/10" : "bg-transparent")}
     >
       <div className="flex flex-col gap-3 px-4 py-4 md:grid md:grid-cols-[minmax(0,2.5fr)_minmax(0,1.2fr)_minmax(0,1.3fr)_minmax(0,1fr)_auto] md:items-center md:gap-4 md:px-6">
         <div className="flex flex-col gap-2">
@@ -910,7 +911,7 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
             <button
               type="button"
               onClick={() => setExpanded((value) => !value)}
-              className="mt-0.5 inline-flex h-11 w-11 flex-none items-center justify-center rounded-full border border-white/10 bg-white/5 text-white transition hover:bg-white/10"
+              className="mt-0.5 inline-flex h-11 w-11 flex-none items-center justify-center rounded-full border border-inverse/10 bg-inverse/5 text-fg transition hover:bg-inverse/10"
               aria-expanded={expanded}
               aria-controls={`topic-details-${item.topic.id}`}
               title={expanded ? "Hide details" : "Show details"}
@@ -922,21 +923,21 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
             </button>
             <div className="min-w-0 space-y-1">
               <div className="flex flex-wrap items-center gap-2">
-                <p className="truncate text-base font-semibold text-white" title={item.topic.title}>
+                <p className="truncate text-base font-semibold text-fg" title={item.topic.title}>
                   {item.topic.title}
                 </p>
                 {editing ? (
-                  <span className="rounded-full bg-white/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-accent">
+                  <span className="rounded-full bg-inverse/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-accent">
                     Editing…
                   </span>
                 ) : null}
               </div>
-              <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400 md:hidden">
+              <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground md:hidden">
                 <span
-                  className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-2.5 py-1"
-                  style={{ backgroundColor: `${(subject?.color ?? "#64748b")}1f` }}
+                  className="inline-flex items-center gap-2 rounded-full border border-inverse/10 bg-inverse/5 px-2.5 py-1"
+                  style={{ backgroundColor: `${(subject?.color ?? FALLBACK_SUBJECT_COLOR)}1f` }}
                 >
-                  <span className="flex h-5 w-5 items-center justify-center rounded-full bg-white/15 text-white">
+                  <span className="flex h-5 w-5 items-center justify-center rounded-full bg-inverse/15 text-fg">
                     <IconPreview name={subject?.icon ?? "Sparkles"} className="h-3.5 w-3.5" />
                   </span>
                   <span>{subject ? subject.name : "No subject"}</span>
@@ -952,20 +953,20 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
             </div>
           </div>
         </div>
-        <div className="hidden min-w-0 items-center gap-2 text-sm text-zinc-200 md:flex">
+        <div className="hidden min-w-0 items-center gap-2 text-sm text-fg/80 md:flex">
           <span
-            className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium"
-            style={{ backgroundColor: `${(subject?.color ?? "#64748b")}1f` }}
+            className="inline-flex items-center gap-2 rounded-full border border-inverse/10 bg-inverse/5 px-3 py-1 text-xs font-medium"
+            style={{ backgroundColor: `${(subject?.color ?? FALLBACK_SUBJECT_COLOR)}1f` }}
           >
-            <span className="flex h-5 w-5 items-center justify-center rounded-full bg-white/15 text-white">
+            <span className="flex h-5 w-5 items-center justify-center rounded-full bg-inverse/15 text-fg">
               <IconPreview name={subject?.icon ?? "Sparkles"} className="h-3.5 w-3.5" />
             </span>
             {subject ? subject.name : "No subject"}
           </span>
         </div>
-        <div className="hidden min-w-0 flex-col text-sm text-zinc-100 md:flex">
-          <span className="font-medium text-white">{nextReviewDateLabel}</span>
-          <span className="text-xs text-zinc-400">{nextReviewRelativeLabel}</span>
+        <div className="hidden min-w-0 flex-col text-sm text-inverse md:flex">
+          <span className="font-medium text-fg">{nextReviewDateLabel}</span>
+          <span className="text-xs text-muted-foreground">{nextReviewRelativeLabel}</span>
         </div>
         <div className="hidden md:flex">
           <span className={cn("inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium", statusMeta.tone)}>
@@ -991,7 +992,7 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
             onClick={onEdit}
             title="Edit topic"
             aria-label="Edit topic"
-            className="h-11 w-11 rounded-full text-zinc-300 hover:text-white"
+            className="h-11 w-11 rounded-full text-muted-foreground hover:text-fg"
           >
             <Pencil className="h-4 w-4" />
           </Button>
@@ -1000,27 +1001,27 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
               <Button
                 size="icon"
                 variant="ghost"
-                className="h-11 w-11 rounded-full text-zinc-300 hover:text-white"
+                className="h-11 w-11 rounded-full text-muted-foreground hover:text-fg"
                 title="More actions"
                 aria-label="More topic actions"
               >
                 <Ellipsis className="h-4 w-4" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-48 rounded-2xl border border-white/10 bg-slate-900/95 p-2 text-sm text-white">
+            <PopoverContent className="w-48 rounded-2xl border border-inverse/10 bg-card/95 p-2 text-sm text-fg">
               <button
                 type="button"
                 onClick={() => {
                   setShowSkipConfirm(true);
                 }}
-                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-zinc-200 transition hover:bg-white/10"
+                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-fg/80 transition hover:bg-inverse/10"
               >
                 <RefreshCw className="h-4 w-4" aria-hidden="true" /> Skip today
               </button>
               <button
                 type="button"
                 onClick={() => setShowDeleteConfirm(true)}
-                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-rose-200 transition hover:bg-rose-500/20"
+                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-error/20 transition hover:bg-error/20"
               >
                 <Trash2 className="h-4 w-4" aria-hidden="true" /> Delete topic
               </button>
@@ -1030,7 +1031,7 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
       </div>
       {hasUsedReviseToday ? (
         <>
-          <p className="px-6 text-[11px] text-zinc-500 md:text-right">{nextAvailabilitySubtext}</p>
+          <p className="px-6 text-[11px] text-muted-foreground/80 md:text-right">{nextAvailabilitySubtext}</p>
           <span id={lockedDescriptionId} className="sr-only">
             {nextAvailabilityMessage}
           </span>
@@ -1039,35 +1040,35 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
       {expanded ? (
         <div
           id={`topic-details-${item.topic.id}`}
-          className="border-t border-white/5 bg-slate-950/40 px-4 py-4 text-sm text-zinc-300 md:px-6"
+          className="border-t border-inverse/5 bg-bg/40 px-4 py-4 text-sm text-muted-foreground md:px-6"
         >
           <div className="grid gap-4 md:grid-cols-2">
             <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Schedule</p>
-              <ul className="space-y-1 text-xs text-zinc-300">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Schedule</p>
+              <ul className="space-y-1 text-xs text-muted-foreground">
                 <li>
-                  <span className="text-zinc-400">Reminder:</span> {reminderLabel}
+                  <span className="text-muted-foreground">Reminder:</span> {reminderLabel}
                 </li>
                 <li>
-                  <span className="text-zinc-400">Intervals:</span> {intervalsLabel}
+                  <span className="text-muted-foreground">Intervals:</span> {intervalsLabel}
                 </li>
                 <li>
-                  <span className="text-zinc-400">Last reviewed:</span> {lastReviewedLabel}
+                  <span className="text-muted-foreground">Last reviewed:</span> {lastReviewedLabel}
                 </li>
                 <li>
-                  <span className="text-zinc-400">Total reviews:</span> {totalReviews}
+                  <span className="text-muted-foreground">Total reviews:</span> {totalReviews}
                 </li>
                 {examDateLabel ? (
                   <li>
-                    <span className="text-zinc-400">Exam:</span> {examDateLabel}
+                    <span className="text-muted-foreground">Exam:</span> {examDateLabel}
                     {typeof daysUntilExam === "number" ? ` • ${daysUntilExam} day${daysUntilExam === 1 ? "" : "s"} left` : ""}
                   </li>
                 ) : null}
               </ul>
             </div>
             <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Notes</p>
-              <p className="whitespace-pre-line text-xs text-zinc-200">{notesPreview}</p>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</p>
+              <p className="whitespace-pre-line text-xs text-fg/80">{notesPreview}</p>
               {notes.length > 180 ? (
                 <button
                   type="button"

--- a/src/components/forms/color-picker.tsx
+++ b/src/components/forms/color-picker.tsx
@@ -16,27 +16,27 @@ export const ColorPicker: React.FC<ColorPickerProps> = ({ value, onChange }) => 
         <Button
           variant="outline"
           size="lg"
-          className="h-11 w-full justify-start gap-3 rounded-xl border-white/10 bg-white/10 text-left text-sm text-zinc-200 hover:bg-white/15"
+          className="h-11 w-full justify-start gap-3 rounded-xl border-inverse/10 bg-inverse/10 text-left text-sm text-fg/80 hover:bg-inverse/15"
         >
-          <span className="h-6 w-6 rounded-full border border-white/20" style={{ backgroundColor: value }} />
+          <span className="h-6 w-6 rounded-full border border-inverse/20" style={{ backgroundColor: value }} />
           <span className="font-medium tracking-tight">{value.toUpperCase()}</span>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-64 space-y-3" sideOffset={12}>
-        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Color</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Color</p>
         <div className="grid grid-cols-5 gap-2">
           {COLOR_OPTIONS.map((option) => (
             <button
               key={option}
               type="button"
               className={cn(
-                "flex aspect-square items-center justify-center rounded-xl border border-white/10 transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+                "flex aspect-square items-center justify-center rounded-xl border border-inverse/10 transition-transform hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
                 option === value && "border-accent ring-2 ring-accent/60"
               )}
               style={{ backgroundColor: option }}
               onClick={() => onChange(option)}
             >
-              {option === value ? <span className="h-2 w-2 rounded-full bg-white" /> : null}
+              {option === value ? <span className="h-2 w-2 rounded-full bg-inverse" /> : null}
             </button>
           ))}
         </div>

--- a/src/components/forms/icon-picker.tsx
+++ b/src/components/forms/icon-picker.tsx
@@ -17,14 +17,14 @@ export const IconPicker: React.FC<IconPickerProps> = ({ value, onChange }) => {
         <Button
           variant="outline"
           size="lg"
-          className="h-11 w-full justify-start gap-3 rounded-xl border-white/10 bg-white/10 text-left text-sm text-zinc-200 hover:bg-white/15"
+          className="h-11 w-full justify-start gap-3 rounded-xl border-inverse/10 bg-inverse/10 text-left text-sm text-fg/80 hover:bg-inverse/15"
         >
           <IconPreview name={value} className="h-5 w-5" />
           <span className="font-medium tracking-tight">{value}</span>
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-72 space-y-3" sideOffset={12}>
-        <p className="text-xs font-semibold uppercase tracking-wide text-zinc-400">Icon</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Icon</p>
         <div className="grid grid-cols-4 gap-3">
           {ICON_OPTIONS.map((option) => (
             <button
@@ -32,7 +32,7 @@ export const IconPicker: React.FC<IconPickerProps> = ({ value, onChange }) => {
               type="button"
               onClick={() => onChange(option)}
               className={cn(
-                "flex h-12 items-center justify-center rounded-xl border border-white/10 bg-white/5 transition-colors hover:border-white/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+                "flex h-12 items-center justify-center rounded-xl border border-inverse/10 bg-inverse/5 transition-colors hover:border-inverse/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
                 option === value && "border-accent"
               )}
             >

--- a/src/components/forms/interval-editor.tsx
+++ b/src/components/forms/interval-editor.tsx
@@ -80,11 +80,11 @@ export const IntervalEditor: React.FC<IntervalEditorProps> = ({ value, onChange 
               className="h-11 w-32 rounded-xl"
               aria-label={`Interval ${index + 1} in days`}
             />
-            <span className="text-sm text-zinc-300">days</span>
+            <span className="text-sm text-muted-foreground">days</span>
             <Button
               type="button"
               variant="ghost"
-              className="ml-auto text-xs text-zinc-400 hover:text-white"
+              className="ml-auto text-xs text-muted-foreground hover:text-fg"
               onClick={() => handleRemove(index)}
             >
               Remove
@@ -97,7 +97,7 @@ export const IntervalEditor: React.FC<IntervalEditorProps> = ({ value, onChange 
         Add interval
       </Button>
 
-      <p className="text-xs text-zinc-400">
+      <p className="text-xs text-muted-foreground">
         Intervals determine when the topic will be reviewed again. The first interval schedules the next session, and you can
         add or remove steps at any time to stay flexible.
       </p>

--- a/src/components/forms/topic-form.tsx
+++ b/src/components/forms/topic-form.tsx
@@ -1,412 +1,1639 @@
-"use client";
-
-import * as React from "react";
-import { useTopicStore } from "@/stores/topics";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select";
-import { IntervalEditor } from "@/components/forms/interval-editor";
-import { DEFAULT_INTERVALS, REMINDER_TIME_OPTIONS } from "@/lib/constants";
-import { toast } from "sonner";
-import { CalendarClock, CheckCircle2, ChevronLeft, ChevronRight, Info } from "lucide-react";
-import { AutoAdjustPreference, Subject } from "@/types/topic";
-import { daysBetween, formatFullDate } from "@/lib/date";
-import { IconPreview } from "@/components/icon-preview";
-
-const defaultIntervals = [...DEFAULT_INTERVALS];
-
-const DEFAULT_AUTO_ADJUST: AutoAdjustPreference = "ask";
-const INTERVAL_BLUEPRINT = [1, 3, 7, 14, 21, 30, 45, 60, 75, 90, 110, 130];
-const MIN_INTERVALS = 5;
-const MAX_INTERVALS = 12;
-
-const AUTO_ADJUST_LABELS: Record<AutoAdjustPreference, string> = {
-  always: "Always adjust automatically",
-  never: "Never adjust automatically",
-  ask: "Ask me each time"
-};
-
-type TopicFormMode = "create" | "edit";
-
-type StepId = "basics" | "details" | "review";
-
-interface TopicFormProps {
-  topicId?: string | null;
-  onSubmitComplete?: (mode: TopicFormMode) => void;
-}
-
-const wizardSteps: { id: StepId; title: string; description: string }[] = [
-  { id: "basics", title: "Basics", description: "Give your topic a clear name and subject." },
-  { id: "details", title: "Details", description: "Decide how reviews behave and add helpful context." },
-  { id: "review", title: "Review & create", description: "Double-check everything before launching." }
-];
-
-const isValidTimeValue = (value: string) => /^([0-1]\d|2[0-3]):([0-5]\d)$/.test(value);
-
-const toDateInputValue = (value: string | null | undefined) => {
-  if (!value) return "";
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  return date.toISOString().slice(0, 10);
-};
-
-const toIsoDateFromInput = (value: string) => {
-  if (!value) return null;
-  const date = new Date(`${value}T00:00:00`);
-  if (Number.isNaN(date.getTime())) return null;
-  return date.toISOString();
-};
-
-const buildExamSuggestion = (examDate: string | null): {
-  intervals: number[];
-  recommendedCount: number;
-  daysUntilExam: number;
-} | null => {
-  if (!examDate) return null;
-  const normalized = examDate.includes("T") ? examDate : `${examDate}T00:00:00`;
-  const exam = new Date(normalized);
-  if (Number.isNaN(exam.getTime())) return null;
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const days = daysBetween(today, exam);
-  if (days <= 0) {
-    return {
-      intervals: [...defaultIntervals],
-      recommendedCount: defaultIntervals.length,
-      daysUntilExam: days
-    };
-  }
-
-  const recommendedCount = Math.max(
-    MIN_INTERVALS,
-    Math.min(MAX_INTERVALS, Math.ceil(days / 21) + 3)
-  );
-
-  const blueprint = INTERVAL_BLUEPRINT.slice(0, recommendedCount);
-  const lastBlueprint = blueprint[blueprint.length - 1] ?? 1;
-  const scale = lastBlueprint > 0 ? Math.max(0.2, Math.min(2, days / lastBlueprint)) : 1;
-
-  const cumulative: number[] = [];
-  blueprint.forEach((value, index) => {
-    const scaled = Math.max(1, Math.round(value * scale));
-    if (index === 0) {
-      cumulative.push(scaled);
-      return;
-    }
-
-    const previous = cumulative[index - 1];
-    cumulative.push(Math.max(previous + 1, scaled));
-  });
-
-  if (cumulative[cumulative.length - 1] > days) {
-    cumulative[cumulative.length - 1] = days;
-    for (let i = cumulative.length - 2; i >= 0; i -= 1) {
-      if (cumulative[i] >= cumulative[i + 1]) {
-        cumulative[i] = Math.max(1, cumulative[i + 1] - 1);
-      }
-    }
-  }
-
-  const intervals = cumulative.map((value, index) =>
-    index === 0 ? Math.max(1, value) : Math.max(1, value - cumulative[index - 1])
-  );
-
-  return {
-    intervals,
-    recommendedCount,
-    daysUntilExam: days
-  };
-};
-
-export const TopicForm: React.FC<TopicFormProps> = ({ topicId = null, onSubmitComplete }) => {
-  const { addTopic, updateTopic, addCategory, categories, subjects, topics } = useTopicStore((state) => ({
-    addTopic: state.addTopic,
-    updateTopic: state.updateTopic,
-    addCategory: state.addCategory,
-    categories: state.categories,
-    subjects: state.subjects,
-    topics: state.topics
-  }));
-
-  const topic = React.useMemo(
-    () => (topicId ? topics.find((item) => item.id === topicId) ?? null : null),
-    [topics, topicId]
-  );
-
-  const isEditing = Boolean(topicId && topic);
-  const lastLoadedTopicRef = React.useRef<string | null>(null);
-
-  const [stepIndex, setStepIndex] = React.useState(0);
-  const [stepError, setStepError] = React.useState<string | null>(null);
-
-  const [title, setTitle] = React.useState("");
-  const [notes, setNotes] = React.useState("");
-  const [categoryId, setCategoryId] = React.useState<string | null>("general");
-  const [categoryLabel, setCategoryLabel] = React.useState("General");
-  const [newCategory, setNewCategory] = React.useState("");
-  const [reminderTime, setReminderTime] = React.useState<string | null>("09:00");
-  const [timeOption, setTimeOption] = React.useState<string>("09:00");
-  const [customTime, setCustomTime] = React.useState("09:00");
-  const [intervals, setIntervals] = React.useState<number[]>(() => [...defaultIntervals]);
-  const [autoAdjustPreference, setAutoAdjustPreference] = React.useState<AutoAdjustPreference>(
-    DEFAULT_AUTO_ADJUST
-  );
-
-  const resetToDefaults = React.useCallback(() => {
-    setTitle("");
-    setNotes("");
-    setCategoryId("general");
-    setCategoryLabel("General");
-    setReminderTime("09:00");
-    setTimeOption("09:00");
-    setCustomTime("09:00");
-    setIntervals([...defaultIntervals]);
-    setNewCategory("");
-    setAutoAdjustPreference(DEFAULT_AUTO_ADJUST);
-    setStepIndex(0);
-    setStepError(null);
-  }, []);
-
-  React.useEffect(() => {
-    if (!topicId) {
-      resetToDefaults();
-      lastLoadedTopicRef.current = null;
-    }
-  }, [topicId, resetToDefaults]);
-
-  const loadTopic = React.useCallback(() => {
-    if (!topic) return;
-
-    lastLoadedTopicRef.current = topic.id;
-
-    setTitle(topic.title);
-    setNotes(topic.notes);
-
-    const normalizedCategoryLabel = topic.categoryLabel?.toLowerCase();
-    const matchedCategory = topic.categoryId
-      ? categories.find((item) => item.id === topic.categoryId)
-      : normalizedCategoryLabel
-      ? categories.find((item) => item.label.toLowerCase() === normalizedCategoryLabel)
-      : undefined;
-
-    const resolvedCategoryId = matchedCategory?.id ?? topic.categoryId ?? "general";
-    const resolvedCategoryLabel = matchedCategory?.label ?? topic.categoryLabel ?? "General";
-
-    setCategoryId(resolvedCategoryId);
-    setCategoryLabel(resolvedCategoryLabel);
-    setIntervals([...topic.intervals]);
-    setNewCategory("");
-    setAutoAdjustPreference(topic.autoAdjustPreference ?? DEFAULT_AUTO_ADJUST);
-
-    if (topic.reminderTime) {
-      const presetMatch = REMINDER_TIME_OPTIONS.find((option) => option.value === topic.reminderTime);
-      if (presetMatch && presetMatch.value !== "custom" && presetMatch.value !== "none") {
-        setTimeOption(presetMatch.value);
-        setReminderTime(presetMatch.value);
-        setCustomTime(presetMatch.value);
-      } else {
-        setTimeOption("custom");
-        setCustomTime(topic.reminderTime);
-        setReminderTime(topic.reminderTime);
-      }
-    } else {
-      setTimeOption("none");
-      setReminderTime(null);
-      setCustomTime("09:00");
-    }
-
-    setStepIndex(0);
-    setStepError(null);
-  }, [topic, categories]);
-
-  React.useEffect(() => {
-    if (!topic || topic.id === lastLoadedTopicRef.current) return;
-    loadTopic();
-  }, [topic, loadTopic]);
-
-  const handleTimeOptionChange = (value: string) => {
-    setTimeOption(value);
-    if (value === "none") {
-      setReminderTime(null);
-      return;
-    }
-    if (value === "custom") {
-      setReminderTime(customTime);
-      return;
-    }
-    setReminderTime(value);
-  };
-
-  const handleCustomTimeChange = (value: string) => {
-    setCustomTime(value);
-    if (isValidTimeValue(value)) {
-      setReminderTime(value);
-    }
-  };
-
-  const handleNewCategoryKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Enter") {
-      event.preventDefault();
-      handleCreateCategory();
-    }
-  };
-
-  const handleCreateCategory = () => {
-    const trimmed = newCategory.trim();
-    if (!trimmed) return;
-    const category = addCategory({ label: trimmed });
-    setCategoryId(category.id);
-    setCategoryLabel(category.label);
-    setNewCategory("");
-    toast.success("Category saved");
-  };
-
-  const handleCategoryChange = (value: string) => {
-    if (value === "create") {
-      setCategoryId("create");
-      return;
-    }
-    setCategoryId(value);
-    const selected = categories.find((item) => item.id === value);
-    setCategoryLabel(selected?.label ?? "");
-  };
-
-  const handleReset = () => {
-    if (isEditing) {
-      loadTopic();
-      return;
-    }
-    resetToDefaults();
-  };
-
-  const validateStep = (step: StepId) => {
-    if (step === "basics") {
-      if (!title.trim()) {
-        setStepError("Give your topic a memorable name before moving on.");
-        return false;
-      }
-    }
-    if (step === "details") {
-      if (intervals.length === 0) {
-        setStepError("Please add at least one review interval.");
-        return false;
-      }
-    }
-    setStepError(null);
-    return true;
-  };
-
-  const goToPreviousStep = () => {
-    setStepError(null);
-    setStepIndex((index) => Math.max(0, index - 1));
-  };
-
-  const selectedSubject = React.useMemo(() => subjects.find((item) => item.id === categoryId) ?? null, [subjects, categoryId]);
-  const selectedSubjectExamDate = selectedSubject?.examDate ?? null;
-  const activeExamDateIso = selectedSubjectExamDate;
-
-  const goToNextStep = () => {
-    const currentStep = wizardSteps[stepIndex].id;
-    if (!validateStep(currentStep)) return;
-    setStepIndex((index) => Math.min(wizardSteps.length - 1, index + 1));
-  };
-
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    const currentStep = wizardSteps[stepIndex].id;
-    if (currentStep !== "review") {
-      goToNextStep();
-      return;
-    }
-
-    const payload = {
-      title: title.trim(),
-      notes,
-      subjectId: categoryId === "create" ? null : categoryId,
-      subjectLabel: categoryId === "create" ? newCategory.trim() : categoryLabel,
-      categoryId: categoryId === "create" ? null : categoryId,
-      categoryLabel: categoryId === "create" ? newCategory.trim() : categoryLabel,
-      reminderTime,
-      intervals: intervals.length > 0 ? intervals : [...defaultIntervals],
-      autoAdjustPreference
-    };
-
-    try {
-      if (categoryId === "create" && newCategory.trim()) {
-        const category = addCategory({ label: newCategory.trim() });
-        payload.categoryId = category.id;
-        payload.categoryLabel = category.label;
-        payload.subjectId = category.id;
-        payload.subjectLabel = category.label;
-      }
-
-      if (isEditing && topic) {
-        updateTopic(topic.id, payload);
-        toast.success("Topic updated");
-        onSubmitComplete?.("edit");
-      } else {
-        addTopic(payload);
-        toast.success("Topic added to your review plan");
-        onSubmitComplete?.("create");
-        resetToDefaults();
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Unable to save topic");
-    }
-  };
-
-  const currentStep = wizardSteps[stepIndex];
-
-  const examSuggestion = React.useMemo(() => buildExamSuggestion(activeExamDateIso), [activeExamDateIso]);
-
-  const handleApplySuggestion = () => {
-    if (!examSuggestion) return;
-    setIntervals(examSuggestion.intervals);
-    toast.success("Intervals updated for your exam timeline");
-  };
-
-  return (
-    <form onSubmit={handleSubmit} data-testid="topic-form" className="space-y-6">
-      <WizardSteps steps={wizardSteps} activeStep={currentStep.id} />
-
-      <div className="rounded-3xl border border-white/5 bg-slate-950/60 p-5 shadow-lg shadow-slate-900/30 backdrop-blur">
-        <header className="mb-4 space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-wide text-zinc-500">
-            Step {stepIndex + 1} of {wizardSteps.length}
-          </p>
-          <h2 className="text-xl font-semibold text-white">{currentStep.title}</h2>
-          <p className="text-sm text-zinc-400">{currentStep.description}</p>
-        </header>
-
-        <WizardStepContent
-          step={currentStep.id}
-          title={title}
-          onTitleChange={setTitle}
-          categories={categories}
-          categoryId={categoryId}
-          categoryLabel={categoryLabel}
-          onCategoryChange={handleCategoryChange}
-          newCategory={newCategory}
-          onNewCategoryChange={setNewCategory}
-          onNewCategoryKeyDown={handleNewCategoryKeyDown}
-          onCreateCategory={handleCreateCategory}
-          selectedSubject={selectedSubject}
-          notes={notes}
-          onNotesChange={setNotes}
-          reminderTime={reminderTime}
-          timeOption={timeOption}
-          onTimeOptionChange={handleTimeOptionChange}
-          customTime={customTime}
-          onCustomTimeChange={handleCustomTimeChange}
-          intervals={intervals}
+"use client";
+
+
+
+import * as React from "react";
+
+import { useTopicStore } from "@/stores/topics";
+
+import { Button } from "@/components/ui/button";
+import { FALLBACK_SUBJECT_COLOR } from "@/lib/colors";
+
+import { Input } from "@/components/ui/input";
+
+import { Label } from "@/components/ui/label";
+
+import { Textarea } from "@/components/ui/textarea";
+
+import {
+
+  Select,
+
+  SelectContent,
+
+  SelectItem,
+
+  SelectTrigger,
+
+  SelectValue
+
+} from "@/components/ui/select";
+
+import { IntervalEditor } from "@/components/forms/interval-editor";
+
+import { DEFAULT_INTERVALS, REMINDER_TIME_OPTIONS } from "@/lib/constants";
+
+import { toast } from "sonner";
+
+import { CalendarClock, CheckCircle2, ChevronLeft, ChevronRight, Info } from "lucide-react";
+
+import { AutoAdjustPreference, Subject } from "@/types/topic";
+
+import { daysBetween, formatFullDate } from "@/lib/date";
+
+import { IconPreview } from "@/components/icon-preview";
+
+
+
+const defaultIntervals = [...DEFAULT_INTERVALS];
+
+
+
+const DEFAULT_AUTO_ADJUST: AutoAdjustPreference = "ask";
+
+const INTERVAL_BLUEPRINT = [1, 3, 7, 14, 21, 30, 45, 60, 75, 90, 110, 130];
+
+const MIN_INTERVALS = 5;
+
+const MAX_INTERVALS = 12;
+
+
+
+const AUTO_ADJUST_LABELS: Record<AutoAdjustPreference, string> = {
+
+  always: "Always adjust automatically",
+
+  never: "Never adjust automatically",
+
+  ask: "Ask me each time"
+
+};
+
+
+
+type TopicFormMode = "create" | "edit";
+
+
+
+type StepId = "basics" | "details" | "review";
+
+
+
+interface TopicFormProps {
+
+  topicId?: string | null;
+
+  onSubmitComplete?: (mode: TopicFormMode) => void;
+
+}
+
+
+
+const wizardSteps: { id: StepId; title: string; description: string }[] = [
+
+  { id: "basics", title: "Basics", description: "Give your topic a clear name and subject." },
+
+  { id: "details", title: "Details", description: "Decide how reviews behave and add helpful context." },
+
+  { id: "review", title: "Review & create", description: "Double-check everything before launching." }
+
+];
+
+
+
+const isValidTimeValue = (value: string) => /^([0-1]\d|2[0-3]):([0-5]\d)$/.test(value);
+
+
+
+const toDateInputValue = (value: string | null | undefined) => {
+
+  if (!value) return "";
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) return "";
+
+  return date.toISOString().slice(0, 10);
+
+};
+
+
+
+const toIsoDateFromInput = (value: string) => {
+
+  if (!value) return null;
+
+  const date = new Date(`${value}T00:00:00`);
+
+  if (Number.isNaN(date.getTime())) return null;
+
+  return date.toISOString();
+
+};
+
+
+
+const buildExamSuggestion = (examDate: string | null): {
+
+  intervals: number[];
+
+  recommendedCount: number;
+
+  daysUntilExam: number;
+
+} | null => {
+
+  if (!examDate) return null;
+
+  const normalized = examDate.includes("T") ? examDate : `${examDate}T00:00:00`;
+
+  const exam = new Date(normalized);
+
+  if (Number.isNaN(exam.getTime())) return null;
+
+  const today = new Date();
+
+  today.setHours(0, 0, 0, 0);
+
+  const days = daysBetween(today, exam);
+
+  if (days <= 0) {
+
+    return {
+
+      intervals: [...defaultIntervals],
+
+      recommendedCount: defaultIntervals.length,
+
+      daysUntilExam: days
+
+    };
+
+  }
+
+
+
+  const recommendedCount = Math.max(
+
+    MIN_INTERVALS,
+
+    Math.min(MAX_INTERVALS, Math.ceil(days / 21) + 3)
+
+  );
+
+
+
+  const blueprint = INTERVAL_BLUEPRINT.slice(0, recommendedCount);
+
+  const lastBlueprint = blueprint[blueprint.length - 1] ?? 1;
+
+  const scale = lastBlueprint > 0 ? Math.max(0.2, Math.min(2, days / lastBlueprint)) : 1;
+
+
+
+  const cumulative: number[] = [];
+
+  blueprint.forEach((value, index) => {
+
+    const scaled = Math.max(1, Math.round(value * scale));
+
+    if (index === 0) {
+
+      cumulative.push(scaled);
+
+      return;
+
+    }
+
+
+
+    const previous = cumulative[index - 1];
+
+    cumulative.push(Math.max(previous + 1, scaled));
+
+  });
+
+
+
+  if (cumulative[cumulative.length - 1] > days) {
+
+    cumulative[cumulative.length - 1] = days;
+
+    for (let i = cumulative.length - 2; i >= 0; i -= 1) {
+
+      if (cumulative[i] >= cumulative[i + 1]) {
+
+        cumulative[i] = Math.max(1, cumulative[i + 1] - 1);
+
+      }
+
+    }
+
+  }
+
+
+
+  const intervals = cumulative.map((value, index) =>
+
+    index === 0 ? Math.max(1, value) : Math.max(1, value - cumulative[index - 1])
+
+  );
+
+
+
+  return {
+
+    intervals,
+
+    recommendedCount,
+
+    daysUntilExam: days
+
+  };
+
+};
+
+
+
+export const TopicForm: React.FC<TopicFormProps> = ({ topicId = null, onSubmitComplete }) => {
+
+  const { addTopic, updateTopic, addCategory, categories, subjects, topics } = useTopicStore((state) => ({
+
+    addTopic: state.addTopic,
+
+    updateTopic: state.updateTopic,
+
+    addCategory: state.addCategory,
+
+    categories: state.categories,
+
+    subjects: state.subjects,
+
+    topics: state.topics
+
+  }));
+
+
+
+  const topic = React.useMemo(
+
+    () => (topicId ? topics.find((item) => item.id === topicId) ?? null : null),
+
+    [topics, topicId]
+
+  );
+
+
+
+  const isEditing = Boolean(topicId && topic);
+
+  const lastLoadedTopicRef = React.useRef<string | null>(null);
+
+
+
+  const [stepIndex, setStepIndex] = React.useState(0);
+
+  const [stepError, setStepError] = React.useState<string | null>(null);
+
+
+
+  const [title, setTitle] = React.useState("");
+
+  const [notes, setNotes] = React.useState("");
+
+  const [categoryId, setCategoryId] = React.useState<string | null>("general");
+
+  const [categoryLabel, setCategoryLabel] = React.useState("General");
+
+  const [newCategory, setNewCategory] = React.useState("");
+
+  const [reminderTime, setReminderTime] = React.useState<string | null>("09:00");
+
+  const [timeOption, setTimeOption] = React.useState<string>("09:00");
+
+  const [customTime, setCustomTime] = React.useState("09:00");
+
+  const [intervals, setIntervals] = React.useState<number[]>(() => [...defaultIntervals]);
+
+  const [autoAdjustPreference, setAutoAdjustPreference] = React.useState<AutoAdjustPreference>(
+
+    DEFAULT_AUTO_ADJUST
+
+  );
+
+
+
+  const resetToDefaults = React.useCallback(() => {
+
+    setTitle("");
+
+    setNotes("");
+
+    setCategoryId("general");
+
+    setCategoryLabel("General");
+
+    setReminderTime("09:00");
+
+    setTimeOption("09:00");
+
+    setCustomTime("09:00");
+
+    setIntervals([...defaultIntervals]);
+
+    setNewCategory("");
+
+    setAutoAdjustPreference(DEFAULT_AUTO_ADJUST);
+
+    setStepIndex(0);
+
+    setStepError(null);
+
+  }, []);
+
+
+
+  React.useEffect(() => {
+
+    if (!topicId) {
+
+      resetToDefaults();
+
+      lastLoadedTopicRef.current = null;
+
+    }
+
+  }, [topicId, resetToDefaults]);
+
+
+
+  const loadTopic = React.useCallback(() => {
+
+    if (!topic) return;
+
+
+
+    lastLoadedTopicRef.current = topic.id;
+
+
+
+    setTitle(topic.title);
+
+    setNotes(topic.notes);
+
+
+
+    const normalizedCategoryLabel = topic.categoryLabel?.toLowerCase();
+
+    const matchedCategory = topic.categoryId
+
+      ? categories.find((item) => item.id === topic.categoryId)
+
+      : normalizedCategoryLabel
+
+      ? categories.find((item) => item.label.toLowerCase() === normalizedCategoryLabel)
+
+      : undefined;
+
+
+
+    const resolvedCategoryId = matchedCategory?.id ?? topic.categoryId ?? "general";
+
+    const resolvedCategoryLabel = matchedCategory?.label ?? topic.categoryLabel ?? "General";
+
+
+
+    setCategoryId(resolvedCategoryId);
+
+    setCategoryLabel(resolvedCategoryLabel);
+
+    setIntervals([...topic.intervals]);
+
+    setNewCategory("");
+
+    setAutoAdjustPreference(topic.autoAdjustPreference ?? DEFAULT_AUTO_ADJUST);
+
+
+
+    if (topic.reminderTime) {
+
+      const presetMatch = REMINDER_TIME_OPTIONS.find((option) => option.value === topic.reminderTime);
+
+      if (presetMatch && presetMatch.value !== "custom" && presetMatch.value !== "none") {
+
+        setTimeOption(presetMatch.value);
+
+        setReminderTime(presetMatch.value);
+
+        setCustomTime(presetMatch.value);
+
+      } else {
+
+        setTimeOption("custom");
+
+        setCustomTime(topic.reminderTime);
+
+        setReminderTime(topic.reminderTime);
+
+      }
+
+    } else {
+
+      setTimeOption("none");
+
+      setReminderTime(null);
+
+      setCustomTime("09:00");
+
+    }
+
+
+
+    setStepIndex(0);
+
+    setStepError(null);
+
+  }, [topic, categories]);
+
+
+
+  React.useEffect(() => {
+
+    if (!topic || topic.id === lastLoadedTopicRef.current) return;
+
+    loadTopic();
+
+  }, [topic, loadTopic]);
+
+
+
+  const handleTimeOptionChange = (value: string) => {
+
+    setTimeOption(value);
+
+    if (value === "none") {
+
+      setReminderTime(null);
+
+      return;
+
+    }
+
+    if (value === "custom") {
+
+      setReminderTime(customTime);
+
+      return;
+
+    }
+
+    setReminderTime(value);
+
+  };
+
+
+
+  const handleCustomTimeChange = (value: string) => {
+
+    setCustomTime(value);
+
+    if (isValidTimeValue(value)) {
+
+      setReminderTime(value);
+
+    }
+
+  };
+
+
+
+  const handleNewCategoryKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+
+    if (event.key === "Enter") {
+
+      event.preventDefault();
+
+      handleCreateCategory();
+
+    }
+
+  };
+
+
+
+  const handleCreateCategory = () => {
+
+    const trimmed = newCategory.trim();
+
+    if (!trimmed) return;
+
+    const category = addCategory({ label: trimmed });
+
+    setCategoryId(category.id);
+
+    setCategoryLabel(category.label);
+
+    setNewCategory("");
+
+    toast.success("Category saved");
+
+  };
+
+
+
+  const handleCategoryChange = (value: string) => {
+
+    if (value === "create") {
+
+      setCategoryId("create");
+
+      return;
+
+    }
+
+    setCategoryId(value);
+
+    const selected = categories.find((item) => item.id === value);
+
+    setCategoryLabel(selected?.label ?? "");
+
+  };
+
+
+
+  const handleReset = () => {
+
+    if (isEditing) {
+
+      loadTopic();
+
+      return;
+
+    }
+
+    resetToDefaults();
+
+  };
+
+
+
+  const validateStep = (step: StepId) => {
+
+    if (step === "basics") {
+
+      if (!title.trim()) {
+
+        setStepError("Give your topic a memorable name before moving on.");
+
+        return false;
+
+      }
+
+    }
+
+    if (step === "details") {
+
+      if (intervals.length === 0) {
+
+        setStepError("Please add at least one review interval.");
+
+        return false;
+
+      }
+
+    }
+
+    setStepError(null);
+
+    return true;
+
+  };
+
+
+
+  const goToPreviousStep = () => {
+
+    setStepError(null);
+
+    setStepIndex((index) => Math.max(0, index - 1));
+
+  };
+
+
+
+  const selectedSubject = React.useMemo(() => subjects.find((item) => item.id === categoryId) ?? null, [subjects, categoryId]);
+
+  const selectedSubjectExamDate = selectedSubject?.examDate ?? null;
+
+  const activeExamDateIso = selectedSubjectExamDate;
+
+
+
+  const goToNextStep = () => {
+
+    const currentStep = wizardSteps[stepIndex].id;
+
+    if (!validateStep(currentStep)) return;
+
+    setStepIndex((index) => Math.min(wizardSteps.length - 1, index + 1));
+
+  };
+
+
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+
+    event.preventDefault();
+
+    const currentStep = wizardSteps[stepIndex].id;
+
+    if (currentStep !== "review") {
+
+      goToNextStep();
+
+      return;
+
+    }
+
+
+
+    const payload = {
+
+      title: title.trim(),
+
+      notes,
+
+      subjectId: categoryId === "create" ? null : categoryId,
+
+      subjectLabel: categoryId === "create" ? newCategory.trim() : categoryLabel,
+
+      categoryId: categoryId === "create" ? null : categoryId,
+
+      categoryLabel: categoryId === "create" ? newCategory.trim() : categoryLabel,
+
+      reminderTime,
+
+      intervals: intervals.length > 0 ? intervals : [...defaultIntervals],
+
+      autoAdjustPreference
+
+    };
+
+
+
+    try {
+
+      if (categoryId === "create" && newCategory.trim()) {
+
+        const category = addCategory({ label: newCategory.trim() });
+
+        payload.categoryId = category.id;
+
+        payload.categoryLabel = category.label;
+
+        payload.subjectId = category.id;
+
+        payload.subjectLabel = category.label;
+
+      }
+
+
+
+      if (isEditing && topic) {
+
+        updateTopic(topic.id, payload);
+
+        toast.success("Topic updated");
+
+        onSubmitComplete?.("edit");
+
+      } else {
+
+        addTopic(payload);
+
+        toast.success("Topic added to your review plan");
+
+        onSubmitComplete?.("create");
+
+        resetToDefaults();
+
+      }
+
+    } catch (error) {
+
+      toast.error(error instanceof Error ? error.message : "Unable to save topic");
+
+    }
+
+  };
+
+
+
+  const currentStep = wizardSteps[stepIndex];
+
+
+
+  const examSuggestion = React.useMemo(() => buildExamSuggestion(activeExamDateIso), [activeExamDateIso]);
+
+
+
+  const handleApplySuggestion = () => {
+
+    if (!examSuggestion) return;
+
+    setIntervals(examSuggestion.intervals);
+
+    toast.success("Intervals updated for your exam timeline");
+
+  };
+
+
+
+  return (
+
+    <form onSubmit={handleSubmit} data-testid="topic-form" className="space-y-6">
+
+      <WizardSteps steps={wizardSteps} activeStep={currentStep.id} />
+
+
+
+      <div className="rounded-3xl border border-inverse/5 bg-bg/60 p-5 shadow-lg shadow-slate-900/30 backdrop-blur">
+
+        <header className="mb-4 space-y-1">
+
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">
+
+            Step {stepIndex + 1} of {wizardSteps.length}
+
+          </p>
+
+          <h2 className="text-xl font-semibold text-fg">{currentStep.title}</h2>
+
+          <p className="text-sm text-muted-foreground">{currentStep.description}</p>
+
+        </header>
+
+
+
+        <WizardStepContent
+
+          step={currentStep.id}
+
+          title={title}
+
+          onTitleChange={setTitle}
+
+          categories={categories}
+
+          categoryId={categoryId}
+
+          categoryLabel={categoryLabel}
+
+          onCategoryChange={handleCategoryChange}
+
+          newCategory={newCategory}
+
+          onNewCategoryChange={setNewCategory}
+
+          onNewCategoryKeyDown={handleNewCategoryKeyDown}
+
+          onCreateCategory={handleCreateCategory}
+
+          selectedSubject={selectedSubject}
+
+          notes={notes}
+
+          onNotesChange={setNotes}
+
+          reminderTime={reminderTime}
+
+          timeOption={timeOption}
+
+          onTimeOptionChange={handleTimeOptionChange}
+
+          customTime={customTime}
+
+          onCustomTimeChange={handleCustomTimeChange}
+
+          intervals={intervals}
+
+          onIntervalsChange={setIntervals}
+
+          selectedSubjectExamDate={selectedSubjectExamDate}
+
+          examSuggestion={examSuggestion}
+
+          onApplySuggestion={handleApplySuggestion}
+
+          autoAdjustPreference={autoAdjustPreference}
+
+          onAutoAdjustPreferenceChange={setAutoAdjustPreference}
+
+        />
+
+
+
+        {stepError ? (
+
+          <p className="mt-4 rounded-2xl border border-warn/40 bg-warn/10 px-3 py-2 text-sm text-warn/30">
+
+            {stepError}
+
+          </p>
+
+        ) : null}
+
+      </div>
+
+
+
+      <footer className="flex items-center justify-between">
+
+        <Button type="button" variant="ghost" onClick={handleReset} className="rounded-2xl text-muted-foreground hover:text-fg">
+
+          Start over
+
+        </Button>
+
+        <div className="flex items-center gap-3">
+
+          <Button
+
+            type="button"
+
+            variant="outline"
+
+            onClick={goToPreviousStep}
+
+            disabled={stepIndex === 0}
+
+            className="gap-2 rounded-2xl border-inverse/20 text-fg disabled:opacity-40"
+
+          >
+
+            <ChevronLeft className="h-4 w-4" /> Back
+
+          </Button>
+
+          {currentStep.id === "review" ? (
+
+            <Button type="submit" className="gap-2 rounded-2xl">
+
+              <CheckCircle2 className="h-4 w-4" /> {isEditing ? "Save changes" : "Create topic"}
+
+            </Button>
+
+          ) : (
+
+            <Button type="button" onClick={goToNextStep} className="gap-2 rounded-2xl">
+
+              Next {currentStep.id === "details" ? "review" : "step"}
+
+              <ChevronRight className="h-4 w-4" />
+
+            </Button>
+
+          )}
+
+        </div>
+
+      </footer>
+
+    </form>
+
+  );
+
+};
+
+
+
+interface WizardStepContentProps {
+
+  step: StepId;
+
+  title: string;
+
+  onTitleChange: (value: string) => void;
+
+  categories: { id: string; label: string; color: string }[];
+
+  categoryId: string | null;
+
+  categoryLabel: string;
+
+  onCategoryChange: (value: string) => void;
+
+  newCategory: string;
+
+  onNewCategoryChange: (value: string) => void;
+
+  onNewCategoryKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+
+  onCreateCategory: () => void;
+
+  selectedSubject: Subject | null;
+
+  notes: string;
+
+  onNotesChange: (value: string) => void;
+
+  reminderTime: string | null;
+
+  timeOption: string;
+
+  onTimeOptionChange: (value: string) => void;
+
+  customTime: string;
+
+  onCustomTimeChange: (value: string) => void;
+
+  intervals: number[];
+
+  onIntervalsChange: (value: number[]) => void;
+
+  selectedSubjectExamDate: string | null;
+
+  examSuggestion: ReturnType<typeof buildExamSuggestion>;
+
+  onApplySuggestion: () => void;
+
+  autoAdjustPreference: AutoAdjustPreference;
+
+  onAutoAdjustPreferenceChange: (value: AutoAdjustPreference) => void;
+
+}
+
+
+
+const WizardStepContent: React.FC<WizardStepContentProps> = ({
+
+  step,
+
+  title,
+
+  onTitleChange,
+
+  categories,
+
+  categoryId,
+
+  categoryLabel,
+
+  onCategoryChange,
+
+  newCategory,
+
+  onNewCategoryChange,
+
+  onNewCategoryKeyDown,
+
+  onCreateCategory,
+
+  selectedSubject,
+
+  notes,
+
+  onNotesChange,
+
+  reminderTime,
+
+  timeOption,
+
+  onTimeOptionChange,
+
+  customTime,
+
+  onCustomTimeChange,
+
+  intervals,
+
+  onIntervalsChange,
+
+  selectedSubjectExamDate,
+
+  examSuggestion,
+
+  onApplySuggestion,
+
+  autoAdjustPreference,
+
+  onAutoAdjustPreferenceChange
+
+}) => {
+
+  const previewIcon = selectedSubject?.icon ?? "Sparkles";
+
+  const previewColor = selectedSubject?.color ?? FALLBACK_SUBJECT_COLOR;
+
+  const fallbackLabel = categoryLabel || "General";
+
+  const previewLabel = selectedSubject?.name ?? fallbackLabel;
+
+  if (step === "basics") {
+
+    return (
+
+      <div className="space-y-6">
+
+        <div className="space-y-2">
+
+          <Label htmlFor="topic">Topic title</Label>
+
+          <Input
+
+            id="topic"
+
+            value={title}
+
+            onChange={(event) => onTitleChange(event.target.value)}
+
+            placeholder="What do you want to remember?"
+
+            className="h-11 rounded-2xl border-inverse/10 bg-inverse/10"
+
+          />
+
+        </div>
+
+
+
+        <div className="space-y-2">
+
+          <Label>Subject</Label>
+
+          <Select value={categoryId ?? undefined} onValueChange={onCategoryChange}>
+
+            <SelectTrigger className="h-11 rounded-2xl border-inverse/10 bg-inverse/10">
+
+              <SelectValue placeholder="Select subject" />
+
+            </SelectTrigger>
+
+            <SelectContent>
+
+              {categories.map((category) => (
+
+                <SelectItem key={category.id} value={category.id}>
+
+                  <span className="flex items-center gap-2">
+
+                    <span className="h-2.5 w-2.5 rounded-full" style={{ backgroundColor: category.color }} />
+
+                    {category.label}
+
+                  </span>
+
+                </SelectItem>
+
+              ))}
+
+              <SelectItem value="create">+ Create new</SelectItem>
+
+            </SelectContent>
+
+          </Select>
+
+          {categoryId === "create" ? (
+
+            <div className="mt-3 flex flex-col gap-3 sm:flex-row">
+
+              <Input
+
+                value={newCategory}
+
+                onChange={(event) => onNewCategoryChange(event.target.value)}
+
+                onKeyDown={onNewCategoryKeyDown}
+
+                placeholder="New subject name"
+
+                className="h-11 rounded-2xl border-inverse/10 bg-inverse/10"
+
+              />
+
+              <Button
+
+                type="button"
+
+                variant="outline"
+
+                size="lg"
+
+                className="sm:w-auto"
+
+                onClick={onCreateCategory}
+
+                disabled={!newCategory.trim()}
+
+              >
+
+                Save
+
+              </Button>
+
+            </div>
+
+          ) : null}
+
+          <p className="text-xs text-muted-foreground">
+
+            Subjects help you group related topics and power the dashboard filters.
+
+          </p>
+
+        </div>
+
+      </div>
+
+    );
+
+  }
+
+
+
+  if (step === "details") {
+
+    return (
+
+      <div className="space-y-6">
+
+        <div className="space-y-2">
+
+          <Label className="flex items-center gap-2">
+
+            Reminder
+
+            <span title="Pick a reminder time to nudge you on days with scheduled reviews." className="text-accent">
+
+              <Info className="h-3.5 w-3.5" />
+
+            </span>
+
+          </Label>
+
+          <Select value={timeOption} onValueChange={onTimeOptionChange}>
+
+            <SelectTrigger className="h-11 rounded-2xl border-inverse/10 bg-inverse/10">
+
+              <SelectValue placeholder="Select reminder time" />
+
+            </SelectTrigger>
+
+            <SelectContent>
+
+              {REMINDER_TIME_OPTIONS.map((option) => (
+
+                <SelectItem key={option.value} value={option.value}>
+
+                  {option.label}
+
+                </SelectItem>
+
+              ))}
+
+            </SelectContent>
+
+          </Select>
+
+          {timeOption === "custom" ? (
+
+            <Input
+
+              type="time"
+
+              value={customTime}
+
+              onChange={(event) => onCustomTimeChange(event.target.value)}
+
+              className="mt-2 h-11 w-40 rounded-2xl border-inverse/10 bg-inverse/10"
+
+            />
+
+          ) : null}
+
+          <p className="text-xs text-muted-foreground">
+
+            Reminders arrive at the chosen time. You can switch them off anytime.
+
+          </p>
+
+        </div>
+
+
+
+        <div className="space-y-3">
+
+          <div className="space-y-2 rounded-2xl border border-inverse/10 bg-inverse/5 p-4 text-sm text-muted-foreground">
+
+            <p className="font-semibold text-fg">Subject exam timeline</p>
+
+            <p className="text-xs text-fg/80">
+
+              Set the exam date for this subject to optimize your review schedule. No reviews will be scheduled after the exam.
+
+            </p>
+
+            {selectedSubjectExamDate ? (
+
+              <p className="text-xs text-success/20">
+
+                No reviews will be scheduled after {formatFullDate(selectedSubjectExamDate)}.
+
+              </p>
+
+            ) : (
+
+              <p className="text-xs text-muted-foreground">
+
+                No exam date set yet. You can update it from the Subjects page whenever you&rsquo;re ready.
+
+              </p>
+
+            )}
+
+          </div>
+
+
+
+          {examSuggestion ? (
+
+            <div className="space-y-2 rounded-2xl border border-accent/30 bg-accent/10 px-4 py-3 text-xs text-accent">
+
+              <p className="font-semibold">
+
+                {examSuggestion.daysUntilExam > 0
+
+                  ? `Exam in ${examSuggestion.daysUntilExam} day${examSuggestion.daysUntilExam === 1 ? "" : "s"}.`
+
+                  : "Exam date is today."}
+
+              </p>
+
+              <p className="text-accent/80">
+
+                We recommend {examSuggestion.recommendedCount} intervals to stay on track. Apply the suggestion to distribute reviews evenly without crossing your exam date.
+
+              </p>
+
+              <Button
+
+                type="button"
+
+                size="sm"
+
+                variant="outline"
+
+                className="rounded-xl border-accent/40 text-accent hover:bg-accent/10"
+
+                onClick={onApplySuggestion}
+
+              >
+
+                Use suggested intervals
+
+              </Button>
+
+            </div>
+
+          ) : null}
+
+
+
+
+
+
+
+          <div className="space-y-2">
+
+            <Label className="flex items-center gap-2">
+
+              Intervals
+
+              <span title="Intervals space your reviews. Longer gaps appear as you succeed." className="text-accent">
+
+                <Info className="h-3.5 w-3.5" />
+
+              </span>
+
+            </Label>
+
+            <div className="rounded-2xl border border-inverse/10 bg-inverse/10 p-4">
+
+              <IntervalEditor value={intervals} onChange={onIntervalsChange} />
+
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+
+              Adjust or add intervals to match your pace. We�ll keep them flexible so reviews never pile up.
+
+            </p>
+
+          </div>
+
+
+
+          <div className="space-y-2">
+
+            <Label className="flex items-center gap-2">
+
+              Auto-adjust preference
+
+              <span title="Decide how the schedule adapts when you review earlier than planned." className="text-accent">
+
+                <Info className="h-3.5 w-3.5" />
+
+              </span>
+
+            </Label>
+
+            <Select value={autoAdjustPreference} onValueChange={(value: AutoAdjustPreference) => onAutoAdjustPreferenceChange(value)}>
+
+              <SelectTrigger className="h-11 rounded-2xl border-inverse/10 bg-inverse/10 text-left">
+
+                <SelectValue placeholder="Choose behaviour" />
+
+              </SelectTrigger>
+
+              <SelectContent>
+
+                {Object.entries(AUTO_ADJUST_LABELS).map(([value, label]) => (
+
+                  <SelectItem key={value} value={value}>
+
+                    {label}
+
+                  </SelectItem>
+
+                ))}
+
+              </SelectContent>
+
+            </Select>
+
+            <p className="text-xs text-muted-foreground">
+
+              You can change this later from the dashboard if you prefer a different level of automation.
+
+            </p>
+
+          </div>
+
+
+
+          <div className="space-y-2 rounded-2xl border border-warn/30 bg-warn/10 px-4 py-3 text-xs text-warn/30">
+
+            <p className="font-semibold">? Skipping today may cause too many reviews to pile up later.</p>
+
+            <p className="text-warn/20/80">
+
+              Use the �Skip today� action sparingly � we�ll rebalance the schedule, but you should still aim to review consistently.
+
+            </p>
+
+          </div>
+
+        </div>
+
+
+
+        <div className="space-y-2">
+
+          <Label className="flex items-center gap-2">
+
+            Notes
+
+            <span title="Add mnemonics or context to refresh your memory fast." className="text-accent">
+
+              <Info className="h-3.5 w-3.5" />
+
+            </span>
+
+          </Label>
+
+          <Textarea
+
+            value={notes}
+
+            onChange={(event) => onNotesChange(event.target.value)}
+
+            placeholder="Capture keywords, mnemonics, or highlights..."
+
+            rows={6}
+
+            className="min-h-[160px] rounded-2xl border-inverse/10 bg-inverse/10"
+
+          />
+
+        </div>
+
+      </div>
+
+    );
+
+  }
+
+
+
+  return (
+
+    <div className="space-y-4 text-sm text-muted-foreground">
+
+      <div className="rounded-2xl border border-inverse/10 bg-inverse/5 p-4">
+
+        <h3 className="text-base font-semibold text-fg">Basics</h3>
+
+        <p className="text-xs text-muted-foreground">{title || "Untitled topic"}</p>
+
+        <div className="mt-2 text-xs text-muted-foreground">
+
+          Subject: <span className="text-fg">{categoryLabel || "General"}</span>
+
+        </div>
+
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+
+        <div className="rounded-2xl border border-inverse/10 bg-inverse/5 p-4">
+
+          <h3 className="text-base font-semibold text-fg">Subject identity</h3>
+
+          <p className="text-xs text-muted-foreground">Topics inherit their look from the assigned subject.</p>
+
+          <div className="mt-3 flex items-center gap-3">
+
+            <span
+
+              className="flex h-12 w-12 items-center justify-center rounded-2xl"
+
+              style={{ backgroundColor: `${previewColor}22` }}
+
+              aria-hidden="true"
+
+            >
+
+              <IconPreview name={previewIcon} className="h-5 w-5" />
+
+            </span>
+
+            <div className="text-xs text-muted-foreground space-y-1">
+
+              <p>
+
+                Subject: <span className="text-fg">{previewLabel}</span>
+
+              </p>
+
+              <p>
+
+                Icon: <span className="text-fg">{previewIcon}</span>
+
+              </p>
+
+              <p>
+
+                Colour: <span className="text-fg">{previewColor}</span>
+
+              </p>
+
+              <p className="mt-1 text-[11px] text-muted-foreground/80">
+
+                Change identity from the Subjects page to update every topic in this subject instantly.
+
+              </p>
+
+            </div>
+
+          </div>
+
+        </div>
+
+        <div className="rounded-2xl border border-inverse/10 bg-inverse/5 p-4 space-y-2">
+
+          <h3 className="text-base font-semibold text-fg">Schedule</h3>
+
+          <p className="text-xs text-muted-foreground">
+
+            Reminder: <span className="text-fg">{timeOption === "none" ? "None" : reminderTime ?? "Custom"}</span>
+
+          </p>
+
+          <p className="text-xs text-muted-foreground">
+
+            Intervals: <span className="text-fg">{intervals.join(", ")} day{intervals.length === 1 ? "" : "s"}</span>
+
+          </p>
+
+          <p className="text-xs text-muted-foreground">
+
+            Auto-adjust: <span className="text-fg">{AUTO_ADJUST_LABELS[autoAdjustPreference]}</span>
+
+          </p>
+
+          <p className="text-xs text-muted-foreground">
+
+            Exam date: <span className="text-fg">{selectedSubjectExamDate ? formatFullDate(selectedSubjectExamDate) : "Not set"}</span>
+
+          </p>
+
+        </div>
+
+      </div>
+
+      <div className="rounded-2xl border border-inverse/10 bg-inverse/5 p-4">
+
+        <h3 className="text-base font-semibold text-fg">Notes preview</h3>
+
+        <p className="text-xs text-muted-foreground">
+
+          {notes.trim() || "Nothing yet � add a note in the previous step to make reviews richer."}
+
+        </p>
+
+      </div>
+
+    </div>
+
+  );
+
+};
+
+
+
+const WizardSteps = ({ steps, activeStep }: { steps: typeof wizardSteps; activeStep: StepId }) => {
+
+  const activeIndex = steps.findIndex((step) => step.id === activeStep);
+
+  return (
+
+    <nav aria-label="Topic creation steps" className="flex items-center justify-between gap-3 rounded-3xl border border-inverse/5 bg-inverse/5 px-4 py-3">
+
+      {steps.map((step, index) => {
+
+        const isActive = step.id === activeStep;
+
+        const isCompleted = index < activeIndex;
+
+        return (
+
+          <div key={step.id} className="flex flex-1 items-center gap-3 text-left">
+
+            <span
+
+              className={`flex h-8 w-8 items-center justify-center rounded-full border text-sm font-semibold ${
+
+                isCompleted
+
+                  ? "border-success/40 bg-success/20 text-success/20"
+
+                  : isActive
+
+                  ? "border-accent/40 bg-accent/15 text-accent"
+
+                  : "border-inverse/10 bg-inverse/5 text-muted-foreground"
+
+              }`}
+
+            >
+
+              {isCompleted ? <CheckCircle2 className="h-4 w-4" /> : index + 1}
+
+            </span>
+
+            <div>
+
+              <p className={`text-xs font-semibold uppercase tracking-wide ${isActive ? "text-fg" : "text-muted-foreground"}`}>
+
+                {step.title}
+
+              </p>
+
+              <p className="text-[11px] text-muted-foreground/80">{step.description}</p>
+
+            </div>
+
+          </div>
+
+        );
+
+      })}
+
+    </nav>
+
+  );
+
+};
+
+
+
+
+
+
+
+
+
+
           onIntervalsChange={setIntervals}
           selectedSubjectExamDate={selectedSubjectExamDate}
           examSuggestion={examSuggestion}

--- a/src/components/forms/topic-form.tsx
+++ b/src/components/forms/topic-form.tsx
@@ -757,7 +757,7 @@ export const TopicForm: React.FC<TopicFormProps> = ({ topicId = null, onSubmitCo
 
 
 
-      <div className="rounded-3xl border border-inverse/5 bg-bg/60 p-5 shadow-lg shadow-slate-900/30 backdrop-blur">
+      <div className="rounded-3xl border border-inverse/5 bg-bg/60 p-5 backdrop-blur">
 
         <header className="mb-4 space-y-1">
 

--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -12,7 +12,7 @@ export const AppShell: React.FC<AppShellProps> = ({ children }) => {
   useAutoSkipOverdue();
 
   return (
-    <div className="flex min-h-screen flex-col bg-surface text-surface-foreground">
+    <div className="flex min-h-screen flex-col bg-bg text-fg">
       <NavigationBar />
       <main className="flex-1">
         <div className="mx-auto w-full max-w-[90rem] px-4 pb-12 pt-6 md:px-6 lg:px-8 xl:px-10">

--- a/src/components/layout/navigation-bar.tsx
+++ b/src/components/layout/navigation-bar.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { useTopicStore } from "@/stores/topics";
 import { Topic } from "@/types/topic";
 import { ProfileMenu } from "@/components/layout/profile-menu";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 type AppRoute = Route<"/"> | Route<"/calendar"> | Route<"/reviews"> | Route<"/timeline"> | Route<"/subjects"> | Route<"/settings">;
 
@@ -59,19 +60,19 @@ export const NavigationBar: React.FC = () => {
   const { due } = React.useMemo(() => computeDueCounts(topics), [topics]);
 
   return (
-    <header className="sticky top-0 z-40 border-b border-white/5 bg-slate-950/80 backdrop-blur">
+    <header className="sticky top-0 z-40 border-b border-border/60 bg-bg/80 backdrop-blur">
       <div className="mx-auto flex w-full max-w-[90rem] items-center justify-between gap-4 px-4 py-4 md:px-6 lg:px-8 xl:px-10">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 text-fg">
           <Button variant="ghost" size="icon" className="md:hidden" aria-label="Open navigation">
             <Menu className="h-5 w-5" />
           </Button>
           <Link href="/" className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-accent">
             <span className="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-accent/20 text-accent">SR</span>
-            <span className="hidden text-white md:block">Spaced Repetition</span>
+            <span className="hidden text-fg md:block">Spaced Repetition</span>
           </Link>
         </div>
 
-        <nav className="hidden items-center gap-2 text-sm font-medium text-zinc-400 md:flex">
+        <nav className="hidden items-center gap-2 text-sm font-medium text-muted-foreground md:flex">
           {navItems.map((item) => {
             const isActive = pathname === item.href || (item.href !== "/" && pathname.startsWith(item.href));
             const Icon = item.icon;
@@ -80,7 +81,7 @@ export const NavigationBar: React.FC = () => {
                 key={item.href}
                 href={item.href}
                 className={`inline-flex items-center gap-2 rounded-xl px-3 py-2 transition-colors ${
-                  isActive ? "bg-white/10 text-white" : "hover:bg-white/10 hover:text-white"
+                  isActive ? "bg-accent/15 text-accent-foreground" : "hover:bg-muted/60 hover:text-fg"
                 }`}
               >
                 <Icon className="h-4 w-4" />
@@ -91,11 +92,12 @@ export const NavigationBar: React.FC = () => {
         </nav>
 
         <div className="flex items-center gap-3">
+          <ThemeToggle />
           <Button
             type="button"
             variant="outline"
             size="sm"
-            className="hidden items-center gap-2 rounded-full border-white/20 text-xs text-white hover:bg-white/10 md:inline-flex"
+            className="hidden items-center gap-2 rounded-full text-xs text-fg hover:bg-muted/60 md:inline-flex"
             onClick={() => router.push("/reviews" as AppRoute)}
           >
             <Bell className="h-3.5 w-3.5" />

--- a/src/components/layout/profile-menu.tsx
+++ b/src/components/layout/profile-menu.tsx
@@ -22,12 +22,12 @@ export const ProfileMenu: React.FC = () => {
 
   const emailClasses = cn(
     "flex w-full items-center justify-between rounded-xl border px-3 py-2 text-left text-sm transition",
-    profile.notifications.email ? "border-accent/40 bg-accent/10 text-accent" : "border-white/10 text-zinc-400 hover:text-zinc-200"
+    profile.notifications.email ? "border-accent/40 bg-accent/10 text-accent" : "border-inverse/10 text-muted-foreground hover:text-fg/80"
   );
 
   const pushClasses = cn(
     "flex w-full items-center justify-between rounded-xl border px-3 py-2 text-left text-sm transition",
-    profile.notifications.push ? "border-accent/40 bg-accent/10 text-accent" : "border-white/10 text-zinc-400 hover:text-zinc-200"
+    profile.notifications.push ? "border-accent/40 bg-accent/10 text-accent" : "border-inverse/10 text-muted-foreground hover:text-fg/80"
   );
 
   return (
@@ -37,30 +37,30 @@ export const ProfileMenu: React.FC = () => {
           type="button"
           variant="ghost"
           size="icon"
-          className="flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-white/10 text-sm font-semibold text-white shadow-sm transition hover:border-white/30"
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-inverse/10 bg-inverse/10 text-sm font-semibold text-fg shadow-sm transition hover:border-inverse/30"
           aria-label="Open profile menu"
         >
           {avatarFallback(profile.name)}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-64 space-y-4 rounded-2xl border-white/10 bg-slate-900/90 p-4 text-sm text-zinc-200 shadow-xl" sideOffset={12}>
+      <PopoverContent className="w-64 space-y-4 rounded-2xl border-inverse/10 bg-card/90 p-4 text-sm text-fg/80 shadow-xl" sideOffset={12}>
         <div className="flex items-center gap-3">
           <span
-            className="flex h-10 w-10 items-center justify-center rounded-full text-sm font-semibold text-white"
+            className="flex h-10 w-10 items-center justify-center rounded-full text-sm font-semibold text-fg"
             style={{ backgroundColor: profile.avatarColor }}
           >
             {avatarFallback(profile.name)}
           </span>
           <div>
-            <p className="text-sm font-semibold text-white">{profile.name}</p>
-            <p className="text-xs text-zinc-400">{profile.email}</p>
+            <p className="text-sm font-semibold text-fg">{profile.name}</p>
+            <p className="text-xs text-muted-foreground">{profile.email}</p>
           </div>
         </div>
 
-        <div className="space-y-2 rounded-2xl border border-white/5 bg-white/5 p-3 text-xs text-zinc-300">
+        <div className="space-y-2 rounded-2xl border border-inverse/5 bg-inverse/5 p-3 text-xs text-muted-foreground">
           <div className="flex items-center justify-between">
             <span>Timezone</span>
-            <span className="font-medium text-white">{profile.timezone}</span>
+            <span className="font-medium text-fg">{profile.timezone}</span>
           </div>
           <button type="button" onClick={() => toggleNotification("email")} className={emailClasses}>
             <span className="flex items-center gap-2"><Bell className="h-4 w-4" /> Email reminders</span>
@@ -76,7 +76,7 @@ export const ProfileMenu: React.FC = () => {
           <Button
             type="button"
             variant="ghost"
-            className="w-full justify-start gap-2 text-zinc-200 hover:text-white"
+            className="w-full justify-start gap-2 text-fg/80 hover:text-fg"
             onClick={() => router.push("/settings")}
           >
             <Settings className="h-4 w-4" /> Profile settings
@@ -84,7 +84,7 @@ export const ProfileMenu: React.FC = () => {
           <Button
             type="button"
             variant="ghost"
-            className="w-full justify-start gap-2 text-zinc-400 hover:text-white"
+            className="w-full justify-start gap-2 text-muted-foreground hover:text-fg"
             onClick={() => router.push("/subjects")}
           >
             <User className="h-4 w-4" /> Manage subjects
@@ -92,14 +92,14 @@ export const ProfileMenu: React.FC = () => {
           <Button
             type="button"
             variant="ghost"
-            className="w-full justify-start gap-2 text-zinc-400 hover:text-white"
+            className="w-full justify-start gap-2 text-muted-foreground hover:text-fg"
             onClick={() => router.push("/reviews")}
           >
             <Bell className="h-4 w-4" /> Today’s reviews
           </Button>
         </div>
 
-        <Button type="button" variant="outline" className="w-full justify-center gap-2 border-white/20 text-xs text-zinc-300">
+        <Button type="button" variant="outline" className="w-full justify-center gap-2 border-inverse/20 text-xs text-muted-foreground">
           <LogOut className="h-4 w-4" /> Sign out
         </Button>
       </PopoverContent>

--- a/src/components/layout/profile-menu.tsx
+++ b/src/components/layout/profile-menu.tsx
@@ -37,13 +37,13 @@ export const ProfileMenu: React.FC = () => {
           type="button"
           variant="ghost"
           size="icon"
-          className="flex h-10 w-10 items-center justify-center rounded-full border border-inverse/10 bg-inverse/10 text-sm font-semibold text-fg shadow-sm transition hover:border-inverse/30"
+          className="flex h-10 w-10 items-center justify-center rounded-full border border-inverse/10 bg-inverse/10 text-sm font-semibold text-fg transition hover:border-inverse/30"
           aria-label="Open profile menu"
         >
           {avatarFallback(profile.name)}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-64 space-y-4 rounded-2xl border-inverse/10 bg-card/90 p-4 text-sm text-fg/80 shadow-xl" sideOffset={12}>
+      <PopoverContent className="w-64 space-y-4 rounded-2xl border-inverse/10 bg-card/90 p-4 text-sm text-fg/80" sideOffset={12}>
         <div className="flex items-center gap-3">
           <span
             className="flex h-10 w-10 items-center justify-center rounded-full text-sm font-semibold text-fg"

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,32 +1,35 @@
 "use client";
 
 import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
-const TOGGLE_OPTIONS = [
-  { key: "light", label: "Light" },
-  { key: "dark", label: "Dark" },
-  { key: "system", label: "System" }
-] as const;
+interface ThemeToggleProps {
+  className?: string;
+  size?: "sm" | "default";
+}
 
-export function ThemeToggle() {
+export function ThemeToggle({ className, size = "sm" }: ThemeToggleProps) {
   const { theme, resolvedTheme, setTheme } = useTheme();
-  const activeTheme = theme ?? resolvedTheme;
+  const activeTheme = (theme ?? resolvedTheme ?? "light") as "light" | "dark";
+  const isDark = activeTheme === "dark";
+  const nextTheme = isDark ? "light" : "dark";
 
   return (
-    <div className="flex items-center gap-2">
-      {TOGGLE_OPTIONS.map((option) => (
-        <Button
-          key={option.key}
-          type="button"
-          variant={activeTheme === option.key ? "default" : "outline"}
-          size="sm"
-          onClick={() => setTheme(option.key)}
-          aria-label={`${option.label} theme`}
-        >
-          {option.label}
-        </Button>
-      ))}
-    </div>
+    <Button
+      type="button"
+      variant="outline"
+      size={size}
+      onClick={() => setTheme(nextTheme)}
+      aria-pressed={isDark}
+      aria-label={`Switch to ${nextTheme} theme`}
+      className={cn("inline-flex items-center gap-2", className)}
+    >
+      {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+      <span className="text-xs font-medium uppercase tracking-wide">
+        {isDark ? "Light" : "Dark"}
+      </span>
+    </Button>
   );
 }

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { Button } from "@/components/ui/button";
+
+const TOGGLE_OPTIONS = [
+  { key: "light", label: "Light" },
+  { key: "dark", label: "Dark" },
+  { key: "system", label: "System" }
+] as const;
+
+export function ThemeToggle() {
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  const activeTheme = theme ?? resolvedTheme;
+
+  return (
+    <div className="flex items-center gap-2">
+      {TOGGLE_OPTIONS.map((option) => (
+        <Button
+          key={option.key}
+          type="button"
+          variant={activeTheme === option.key ? "default" : "outline"}
+          size="sm"
+          onClick={() => setTheme(option.key)}
+          aria-label={`${option.label} theme`}
+        >
+          {option.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/topics/history-editor.tsx
+++ b/src/components/topics/history-editor.tsx
@@ -604,7 +604,7 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
       animate={{ scale: 1, opacity: 1 }}
       exit={{ scale: 0.9, opacity: 0 }}
       transition={{ type: "spring", stiffness: 260, damping: 26 }}
-      className="flex max-h-[90vh] w-full max-w-4xl flex-col gap-6 rounded-3xl border border-inverse/10 bg-card/95 p-6 shadow-2xl"
+      className="flex max-h-[90vh] w-full max-w-4xl flex-col gap-6 rounded-3xl border border-inverse/10 bg-card/95 p-6"
     >
       {panelBody}
     </motion.div>
@@ -615,7 +615,7 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
       role="region"
       aria-labelledby="history-editor-title"
       aria-describedby="history-editor-description"
-      className="flex w-full max-w-4xl flex-col gap-6 rounded-3xl border border-inverse/10 bg-card/95 p-6 shadow-2xl"
+      className="flex w-full max-w-4xl flex-col gap-6 rounded-3xl border border-inverse/10 bg-card/95 p-6"
     >
       {panelBody}
     </div>

--- a/src/components/topics/history-editor.tsx
+++ b/src/components/topics/history-editor.tsx
@@ -409,23 +409,23 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
         <div className="inline-flex items-center gap-2 rounded-full bg-accent/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-accent">
           <Calendar className="h-3.5 w-3.5" /> Edit history
         </div>
-        <h2 id="history-editor-title" className="text-2xl font-semibold text-white">
+        <h2 id="history-editor-title" className="text-2xl font-semibold text-fg">
           Edit history - {topic.title}
         </h2>
-        <p id="history-editor-description" className="text-sm text-zinc-300">
+        <p id="history-editor-description" className="text-sm text-muted-foreground">
           Backfill past reviews so retention curves stay continuous and schedules reflect when you actually studied.
         </p>
       </header>
 
       {error ? (
-        <div className="flex items-start gap-3 rounded-2xl border border-rose-500/40 bg-rose-500/10 p-3 text-sm text-rose-100">
+        <div className="flex items-start gap-3 rounded-2xl border border-error/40 bg-error/10 p-3 text-sm text-error/20">
           <AlertTriangle className="mt-0.5 h-4 w-4" />
           <span>{error}</span>
         </div>
       ) : null}
 
       {overflowCount > 0 ? (
-        <div className="flex items-start gap-3 rounded-2xl border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-100">
+        <div className="flex items-start gap-3 rounded-2xl border border-warn/40 bg-warn/10 p-3 text-xs text-warn/20">
           <Info className="mt-0.5 h-4 w-4" />
           <span>
             Showing the latest {MAX_HISTORY_ENTRIES} reviews. {overflowCount} older entr{overflowCount === 1 ? "y is" : "ies are"} hidden from editing.
@@ -433,10 +433,10 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
         </div>
       ) : null}
 
-      <ScrollArea className="flex-1 rounded-2xl border border-white/5 bg-slate-900/60 p-4">
+      <ScrollArea className="flex-1 rounded-2xl border border-inverse/5 bg-card/60 p-4">
         <div className="space-y-4">
           {drafts.length === 0 ? (
-            <div className="rounded-2xl border border-dashed border-white/10 bg-slate-900/50 p-6 text-center text-sm text-zinc-400">
+            <div className="rounded-2xl border border-dashed border-inverse/10 bg-card/50 p-6 text-center text-sm text-muted-foreground">
               No past reviews yet.
             </div>
           ) : (
@@ -447,7 +447,7 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
               return (
                 <div
                   key={draft.localId}
-                  className="grid gap-3 rounded-2xl border border-white/10 bg-slate-900/70 p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_auto]"
+                  className="grid gap-3 rounded-2xl border border-inverse/10 bg-card/70 p-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)_auto]"
                 >
                   <div className="space-y-1">
                     <Label htmlFor={`history-date-${draft.localId}`}>Date</Label>
@@ -499,8 +499,8 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
                       <Trash2 className="h-4 w-4" />
                     </Button>
                   </div>
-                  <p className="md:col-span-3 text-xs text-zinc-400">
-                    Saved quality: <span className="font-medium text-white">{QUALITY_LABEL[draft.quality]}</span>
+                  <p className="md:col-span-3 text-xs text-muted-foreground">
+                    Saved quality: <span className="font-medium text-fg">{QUALITY_LABEL[draft.quality]}</span>
                   </p>
                 </div>
               );
@@ -519,16 +519,16 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
           >
             <Plus className="h-4 w-4" /> Add entry
           </Button>
-          <span className="text-xs text-zinc-400">
+          <span className="text-xs text-muted-foreground">
             Entries are sorted chronologically and merged on the same day using the highest quality. Up to {MAX_HISTORY_ENTRIES} entries per topic. {remainingSlots > 0 ? `${remainingSlots} slot${remainingSlots === 1 ? '' : 's'} remaining.` : `Adding more hides the oldest entry.`}
           </span>
         </div>
 
-        <div className="space-y-3 rounded-2xl border border-white/10 bg-slate-900/70 p-4">
-          <div className="flex items-center gap-2 text-sm font-semibold text-white">
+        <div className="space-y-3 rounded-2xl border border-inverse/10 bg-card/70 p-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-fg">
             <ClipboardList className="h-4 w-4" /> Bulk add from pasted dates
           </div>
-          <p className="text-xs text-zinc-400">
+          <p className="text-xs text-muted-foreground">
             Paste one date per line (YYYY-MM-DD). Optionally include a quality token (easy, hard, forgot). Missing tokens use the selected default quality.
           </p>
           <div className="grid gap-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto]">
@@ -536,7 +536,7 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
               value={bulkInput}
               onChange={(event) => setBulkInput(event.target.value)}
               rows={3}
-              className="min-h-[96px] resize-y rounded-2xl border border-white/10 bg-slate-950/50 p-3 text-sm text-white focus:outline-none focus:ring-2 focus:ring-accent/50"
+              className="min-h-[96px] resize-y rounded-2xl border border-inverse/10 bg-bg/50 p-3 text-sm text-fg focus:outline-none focus:ring-2 focus:ring-accent/50"
               placeholder="2024-03-01 easy\n2024-03-05 hard\n2024-03-12"
             />
             <div className="space-y-1">
@@ -571,8 +571,8 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
         </div>
       </div>
 
-      <footer className="flex flex-col gap-3 border-t border-white/5 pt-4 md:flex-row md:items-center md:justify-between">
-        <div className="text-xs text-zinc-400">
+      <footer className="flex flex-col gap-3 border-t border-inverse/5 pt-4 md:flex-row md:items-center md:justify-between">
+        <div className="text-xs text-muted-foreground">
           {subject?.examDate ? (
             <span>
               Reviews must stay on or before {formatDateWithWeekday(subject.examDate)}.
@@ -604,7 +604,7 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
       animate={{ scale: 1, opacity: 1 }}
       exit={{ scale: 0.9, opacity: 0 }}
       transition={{ type: "spring", stiffness: 260, damping: 26 }}
-      className="flex max-h-[90vh] w-full max-w-4xl flex-col gap-6 rounded-3xl border border-white/10 bg-slate-900/95 p-6 shadow-2xl"
+      className="flex max-h-[90vh] w-full max-w-4xl flex-col gap-6 rounded-3xl border border-inverse/10 bg-card/95 p-6 shadow-2xl"
     >
       {panelBody}
     </motion.div>
@@ -615,7 +615,7 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
       role="region"
       aria-labelledby="history-editor-title"
       aria-describedby="history-editor-description"
-      className="flex w-full max-w-4xl flex-col gap-6 rounded-3xl border border-white/10 bg-slate-900/95 p-6 shadow-2xl"
+      className="flex w-full max-w-4xl flex-col gap-6 rounded-3xl border border-inverse/10 bg-card/95 p-6 shadow-2xl"
     >
       {panelBody}
     </div>
@@ -656,7 +656,7 @@ export const TopicHistoryEditor: React.FC<TopicHistoryEditorProps> = ({
         <motion.div
           key="history-editor"
           ref={overlayRef}
-          className="fixed inset-0 z-[1200] flex items-center justify-center bg-slate-950/70 backdrop-blur"
+          className="fixed inset-0 z-[1200] flex items-center justify-center bg-bg/70 backdrop-blur"
           role="presentation"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,13 +4,13 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:pointer-events-none disabled:opacity-60",
+  "inline-flex items-center justify-center gap-2 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:pointer-events-none disabled:opacity-60",
   {
     variants: {
       variant: {
         default: "bg-accent text-accent-foreground hover:bg-accent/90",
-        outline: "border border-border bg-surface hover:bg-muted",
-        ghost: "hover:bg-muted"
+        outline: "border border-border bg-card text-fg hover:bg-muted/80",
+        ghost: "text-fg hover:bg-muted/60"
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/components/ui/confirmation-dialog.tsx
+++ b/src/components/ui/confirmation-dialog.tsx
@@ -128,7 +128,7 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
         <motion.div
           key="confirmation-dialog"
           ref={overlayRef}
-          className="fixed inset-0 z-[1100] flex items-center justify-center bg-slate-950/70 backdrop-blur"
+          className="fixed inset-0 z-[1100] flex items-center justify-center bg-bg/70 backdrop-blur"
           role="presentation"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -149,29 +149,29 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.9, opacity: 0 }}
             transition={{ type: "spring", stiffness: 260, damping: 26 }}
-            className="w-full max-w-md rounded-3xl border border-white/10 bg-slate-900/90 p-6 shadow-2xl"
+            className="w-full max-w-md rounded-3xl border border-inverse/10 bg-card/90 p-6 shadow-2xl"
           >
             <div className="flex items-start gap-3">
-              {icon ? <span className="mt-1 rounded-2xl bg-white/10 p-2 text-accent" aria-hidden="true">{icon}</span> : null}
+              {icon ? <span className="mt-1 rounded-2xl bg-inverse/10 p-2 text-accent" aria-hidden="true">{icon}</span> : null}
               <div className="space-y-2">
-                <h2 id={titleId} className="text-lg font-semibold text-white">
+                <h2 id={titleId} className="text-lg font-semibold text-fg">
                   {title}
                 </h2>
-                <p id={descriptionId} className="text-sm text-zinc-300">
+                <p id={descriptionId} className="text-sm text-muted-foreground">
                   {description}
                 </p>
-                {warning ? <p className="text-xs font-semibold text-amber-200">{warning}</p> : null}
+                {warning ? <p className="text-xs font-semibold text-warn/30">{warning}</p> : null}
               </div>
             </div>
             {extraActions && extraActions.length > 0 ? (
-              <div className="mt-4 space-y-2 rounded-2xl border border-white/10 bg-white/5 p-3 text-xs text-zinc-300">
-                <p className="font-semibold text-white">Quick preferences</p>
+              <div className="mt-4 space-y-2 rounded-2xl border border-inverse/10 bg-inverse/5 p-3 text-xs text-muted-foreground">
+                <p className="font-semibold text-fg">Quick preferences</p>
                 {extraActions.map((action) => (
                   <button
                     key={action.label}
                     type="button"
                     onClick={action.action}
-                    className="w-full rounded-xl border border-white/10 px-3 py-2 text-left transition hover:border-accent/40 hover:text-accent"
+                    className="w-full rounded-xl border border-inverse/10 px-3 py-2 text-left transition hover:border-accent/40 hover:text-accent"
                   >
                     {action.label}
                   </button>
@@ -188,9 +188,9 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
                 className={cn(
                   "min-w-[140px] rounded-2xl",
                   confirmTone === "danger"
-                    ? "bg-rose-500/80 hover:bg-rose-500 text-white"
+                    ? "bg-error/80 hover:bg-error text-fg"
                     : confirmTone === "warning"
-                    ? "bg-amber-500/80 hover:bg-amber-500 text-slate-900"
+                    ? "bg-warn/80 hover:bg-warn text-inverse-foreground"
                     : ""
                 )}
               >

--- a/src/components/ui/confirmation-dialog.tsx
+++ b/src/components/ui/confirmation-dialog.tsx
@@ -149,7 +149,7 @@ export const ConfirmationDialog: React.FC<ConfirmationDialogProps> = ({
             animate={{ scale: 1, opacity: 1 }}
             exit={{ scale: 0.9, opacity: 0 }}
             transition={{ type: "spring", stiffness: 260, damping: 26 }}
-            className="w-full max-w-md rounded-3xl border border-inverse/10 bg-card/90 p-6 shadow-2xl"
+            className="w-full max-w-md rounded-3xl border border-inverse/10 bg-card/90 p-6"
           >
             <div className="flex items-start gap-3">
               {icon ? <span className="mt-1 rounded-2xl bg-inverse/10 p-2 text-accent" aria-hidden="true">{icon}</span> : null}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type 
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-surface-foreground shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-60",
+        "flex h-10 w-full rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-fg transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-60",
         className
       )}
       ref={ref}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type 
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-surface-foreground shadow-sm transition-colors placeholder:text-zinc-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-60",
+        "flex h-10 w-full rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-surface-foreground shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-60",
         className
       )}
       ref={ref}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -6,7 +6,7 @@ export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> 
 const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ className, ...props }, ref) => (
   <label
     ref={ref}
-    className={cn("text-xs font-semibold uppercase tracking-wide text-zinc-300", className)}
+    className={cn("text-xs font-semibold uppercase tracking-wide text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -15,7 +15,7 @@ const PopoverContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 w-64 rounded-xl border border-border bg-surface/95 p-3 text-sm text-surface-foreground shadow-lg backdrop-blur",
+      "z-50 w-64 rounded-xl border border-border bg-card p-3 text-sm text-fg backdrop-blur",
       className
     )}
     {...props}

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -30,7 +30,7 @@ const ScrollBar = React.forwardRef<
     )}
     {...props}
   >
-    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-zinc-600" />
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-muted" />
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
 ));
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -57,7 +57,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("px-2 py-1.5 text-xs font-semibold text-zinc-400", className)}
+    className={cn("px-2 py-1.5 text-xs font-semibold text-muted-foreground", className)}
     {...props}
   />
 ));

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -16,7 +16,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between gap-2 rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-surface-foreground shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-60",
+      "flex h-10 w-full items-center justify-between gap-2 rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-fg focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-60",
       className
     )}
     {...props}
@@ -37,7 +37,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-border bg-surface/95 text-surface-foreground shadow-lg backdrop-blur supports-[backdrop-filter]:bg-surface/80",
+        "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-border bg-card text-fg backdrop-blur supports-[backdrop-filter]:bg-card/90",
         className
       )}
       position={position}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
   return (
     <textarea
       className={cn(
-        "flex min-h-[120px] w-full rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-surface-foreground shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-60",
+        "flex min-h-[120px] w-full rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-fg transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-60",
         className
       )}
       ref={ref}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
   return (
     <textarea
       className={cn(
-        "flex min-h-[120px] w-full rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-surface-foreground shadow-sm transition-colors placeholder:text-zinc-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-60",
+        "flex min-h-[120px] w-full rounded-lg border border-border bg-card/60 px-3 py-2 text-sm text-surface-foreground shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface disabled:cursor-not-allowed disabled:opacity-60",
         className
       )}
       ref={ref}

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -15,10 +15,10 @@ export const Toggle = React.forwardRef<
     <TogglePrimitive.Root
       ref={ref}
       className={cn(
-        "inline-flex items-center gap-2 rounded-xl px-3 py-2 text-xs font-medium uppercase tracking-wide transition",
-        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-950",
-        "data-[state=on]:bg-accent/20 data-[state=on]:text-white",
-        "data-[state=off]:text-zinc-300 data-[state=off]:hover:text-white",
+        "inline-flex items-center gap-2 rounded-xl border border-inverse/10 bg-bg/30 px-3 py-2 text-xs font-medium uppercase tracking-wide transition",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+        "data-[state=on]:border-accent/40 data-[state=on]:bg-accent/25 data-[state=on]:text-fg",
+        "data-[state=off]:text-muted-foreground data-[state=off]:hover:border-inverse/20 data-[state=off]:hover:bg-card/60 data-[state=off]:hover:text-fg",
         "disabled:pointer-events-none disabled:opacity-50",
         className
       )}

--- a/src/components/visualizations/timeline-chart.tsx
+++ b/src/components/visualizations/timeline-chart.tsx
@@ -1253,7 +1253,7 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
               aria-label={`Exam date for ${marker.subjectName}, ${examDateFormatter.format(new Date(marker.dateISO))}`}
             >
               <foreignObject x={-80} y={-18} width={160} height={26}>
-                <div className="pointer-events-none flex items-center gap-1 rounded-full bg-card/90 px-3 py-1 text-[10px] font-medium text-fg shadow-lg">
+                <div className="pointer-events-none flex items-center gap-1 rounded-full bg-card/90 px-3 py-1 text-[10px] font-medium text-fg">
                   <span className="inline-flex h-2 w-2 rounded-full" style={{ backgroundColor: marker.color }} />
                   <span className="uppercase text-[9px] tracking-wide text-accent">Exam</span>
                   <span className="max-w-[90px] truncate">{marker.subjectName}</span>
@@ -1295,7 +1295,7 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
           aria-label={`Upcoming exams: ${cluster.items.map((item) => item.subjectName).join(", ")}`}
         >
           <foreignObject x={-70} y={-18} width={140} height={26}>
-            <div className="pointer-events-none flex items-center justify-center rounded-full bg-card/90 px-3 py-1 text-[10px] font-semibold text-fg shadow-lg">
+            <div className="pointer-events-none flex items-center justify-center rounded-full bg-card/90 px-3 py-1 text-[10px] font-semibold text-fg">
               {label}
             </div>
           </foreignObject>
@@ -1490,7 +1490,7 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
                   width={220}
                   height={64}
                 >
-                  <div className="pointer-events-none rounded-md bg-bg/80 px-3 py-2 text-[11px] text-fg shadow-lg">
+                  <div className="pointer-events-none rounded-md bg-bg/80 px-3 py-2 text-[11px] text-fg">
                     <div className="font-semibold">{selectionLabel.primary}</div>
                     {selectionRect.shift && selectionLabel.secondary ? (
                       <div className="text-[10px] text-accent/20">{selectionLabel.secondary}</div>

--- a/src/components/visualizations/timeline-chart.tsx
+++ b/src/components/visualizations/timeline-chart.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as React from "react";
+import { softenColorTone } from "@/lib/colors";
 import { startOfDayInTimeZone } from "@/lib/date";
 
 export type TimelinePoint = { t: number; r: number; opacity: number };
@@ -33,6 +34,7 @@ export type TimelineSeries = {
   color: string;
   points: TimelinePoint[];
   segments: TimelineSegment[];
+  connectors: { id: string; from: TimelinePoint; to: TimelinePoint }[];
   stitches: TimelineStitch[];
   events: {
     id: string;
@@ -55,12 +57,6 @@ export type TimelineExamMarker = {
 
 type MarkerItem = TimelineExamMarker & { x: number };
 type MarkerCluster = { items: MarkerItem[]; x: number };
-type MarkerTooltip = {
-  x: number;
-  y: number;
-  title?: string;
-  items: { subjectName: string; dateISO: string; daysRemaining: number | null; color: string }[];
-};
 
 type TimelineViewport = {
   x: [number, number];
@@ -124,8 +120,10 @@ interface TimelineChartProps {
   onRequestStepBack?: () => void;
   onTooSmallSelection?: () => void;
   keyboardSelection?: KeyboardBand | null;
-  showOpacityFade?: boolean;
-  showReviewLines?: boolean;
+  showOpacityGradient?: boolean;
+  showReviewMarkers?: boolean;
+  showEventDots?: boolean;
+  showTopicLabels?: boolean;
 }
 
 const PADDING_X = 48;
@@ -160,6 +158,101 @@ const clampRange = (range: RangeTuple, bounds: RangeTuple | undefined, minSpan: 
   return [start, end];
 };
 
+type XYPoint = { x: number; y: number };
+
+const MONOTONE_EPSILON = 1e-6;
+
+const computeMonotoneTangents = (points: XYPoint[]): number[] => {
+  const count = points.length;
+  const tangents = new Array<number>(count).fill(0);
+  if (count < 2) {
+    return tangents;
+  }
+
+  const slopes: number[] = new Array(count - 1);
+  for (let index = 0; index < count - 1; index += 1) {
+    const current = points[index];
+    const next = points[index + 1];
+    const dx = next.x - current.x;
+    slopes[index] = Math.abs(dx) < MONOTONE_EPSILON ? 0 : (next.y - current.y) / dx;
+  }
+
+  tangents[0] = slopes[0] ?? 0;
+  tangents[count - 1] = slopes[slopes.length - 1] ?? 0;
+
+  for (let index = 1; index < count - 1; index += 1) {
+    const prev = slopes[index - 1];
+    const next = slopes[index];
+    if (prev === 0 || next === 0 || (prev < 0 && next > 0) || (prev > 0 && next < 0)) {
+      tangents[index] = 0;
+    } else {
+      tangents[index] = (prev + next) / 2;
+    }
+  }
+
+  for (let index = 0; index < slopes.length; index += 1) {
+    const slope = slopes[index];
+    if (slope === 0) {
+      tangents[index] = 0;
+      tangents[index + 1] = 0;
+      continue;
+    }
+    const a = tangents[index] / slope;
+    const b = tangents[index + 1] / slope;
+    const magnitude = Math.hypot(a, b);
+    if (magnitude > 3) {
+      const scale = 3 / magnitude;
+      tangents[index] = scale * a * slope;
+      tangents[index + 1] = scale * b * slope;
+    }
+  }
+
+  return tangents;
+};
+
+const buildMonotoneCommands = (points: XYPoint[], tangents: number[]): string[] => {
+  if (points.length === 0) return [];
+  const commands: string[] = [`M ${points[0].x} ${points[0].y}`];
+  for (let index = 0; index < points.length - 1; index += 1) {
+    const current = points[index];
+    const next = points[index + 1];
+    const dx = next.x - current.x;
+    if (Math.abs(dx) < MONOTONE_EPSILON) {
+      commands.push(`L ${next.x} ${next.y}`);
+      continue;
+    }
+    const t0 = tangents[index];
+    const t1 = tangents[index + 1];
+    const x1 = current.x + dx / 3;
+    const y1 = current.y + (dx / 3) * t0;
+    const x2 = next.x - dx / 3;
+    const y2 = next.y - (dx / 3) * t1;
+    commands.push(`C ${x1} ${y1} ${x2} ${y2} ${next.x} ${next.y}`);
+  }
+  return commands;
+};
+
+const createSmoothPaths = (
+  points: TimelinePoint[],
+  scaleX: (time: number) => number,
+  scaleY: (value: number) => number,
+  baselineY: number
+): { line: string; area: string | null } | null => {
+  if (!points || points.length === 0) return null;
+  const coords = points.map((point) => ({ x: scaleX(point.t), y: scaleY(point.r) }));
+  if (coords.length === 1) {
+    const only = coords[0];
+    const linePath = `M ${only.x} ${only.y}`;
+    return { line: linePath, area: `${linePath} L ${only.x} ${baselineY} Z` };
+  }
+  const tangents = computeMonotoneTangents(coords);
+  const commands = buildMonotoneCommands(coords, tangents);
+  const linePath = commands.join(" ");
+  const closing = [`L ${coords[coords.length - 1].x} ${baselineY}`, `L ${coords[0].x} ${baselineY}`, "Z"];
+  const areaPath = [...commands, ...closing].join(" ");
+  return { line: linePath, area: areaPath };
+};
+
 const ensureSpan = (range: RangeTuple, minSpan: number): RangeTuple => {
   const span = range[1] - range[0];
   if (span >= minSpan) return range;
@@ -188,8 +281,10 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
       onRequestStepBack,
       onTooSmallSelection,
       keyboardSelection,
-      showOpacityFade = true,
-      showReviewLines = false
+      showOpacityGradient = true,
+      showReviewMarkers = false,
+      showEventDots = true,
+      showTopicLabels = true
     },
     ref
   ) => {
@@ -202,6 +297,11 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
     const makeGradientId = React.useCallback(
       (topicId: string, segmentId: string) =>
         `${gradientPrefix}-${topicId}-${segmentId}`.replace(/[^a-zA-Z0-9_-]/g, "-"),
+      [gradientPrefix]
+    );
+
+    const makeAreaGradientId = React.useCallback(
+      (topicId: string) => `${gradientPrefix}-area-${topicId}`.replace(/[^a-zA-Z0-9_-]/g, "-"),
       [gradientPrefix]
     );
 
@@ -321,10 +421,26 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
       [yDomain, ySpan, plotHeight, height]
     );
 
+    const baselineY = React.useMemo(() => scaleY(yDomain[0]), [scaleY, yDomain]);
+
+    const displayColorByTopic = React.useMemo(() => {
+      const map = new Map<string, string>();
+      for (const line of series) {
+        map.set(line.topicId, softenColorTone(line.color));
+      }
+      return map;
+    }, [series]);
+
+    const resolveDisplayColor = React.useCallback(
+      (line: TimelineSeries) => displayColorByTopic.get(line.topicId) ?? line.color,
+      [displayColorByTopic]
+    );
+
     const segmentGradients = React.useMemo(() => {
-      if (!showOpacityFade) return [] as React.ReactNode[];
+      if (!showOpacityGradient) return [] as React.ReactNode[];
       const defs: React.ReactNode[] = [];
       for (const line of series) {
+        const color = resolveDisplayColor(line);
         for (const segment of line.segments) {
           if (segment.points.length === 0) continue;
           const gradientId = makeGradientId(line.topicId, segment.id);
@@ -354,13 +470,13 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
             >
               {reversed ? (
                 <>
-                  <stop offset="0%" stopColor={line.color} stopOpacity={1} />
-                  <stop offset="100%" stopColor={line.color} stopOpacity={0} />
+                  <stop offset="0%" stopColor={color} stopOpacity={1} />
+                  <stop offset="100%" stopColor={color} stopOpacity={0} />
                 </>
               ) : (
                 <>
-                  <stop offset="0%" stopColor={line.color} stopOpacity={0} />
-                  <stop offset="100%" stopColor={line.color} stopOpacity={1} />
+                  <stop offset="0%" stopColor={color} stopOpacity={0} />
+                  <stop offset="100%" stopColor={color} stopOpacity={1} />
                 </>
               )}
             </linearGradient>
@@ -368,7 +484,67 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
         }
       }
       return defs;
-    }, [series, scaleX, makeGradientId, showOpacityFade]);
+    }, [series, scaleX, makeGradientId, showOpacityGradient, resolveDisplayColor]);
+
+    const connectorGradients = React.useMemo(() => {
+      if (!showOpacityGradient) return [] as React.ReactNode[];
+      const defs: React.ReactNode[] = [];
+      for (const line of series) {
+        const color = resolveDisplayColor(line);
+        for (const connector of line.connectors) {
+          const gradientId = makeGradientId(line.topicId, `connector-${connector.id}`);
+          let x1 = scaleX(connector.from.t);
+          let x2 = scaleX(connector.to.t);
+          if (!Number.isFinite(x1) || !Number.isFinite(x2)) continue;
+          if (x1 === x2) {
+            x2 = x1 + 0.001;
+          }
+          defs.push(
+            <linearGradient
+              key={gradientId}
+              id={gradientId}
+              gradientUnits="userSpaceOnUse"
+              x1={x1}
+              y1={0}
+              x2={x2}
+              y2={0}
+            >
+              <stop
+                offset="0%"
+                stopColor={color}
+                stopOpacity={clampValue(connector.from.opacity, 0, 1)}
+              />
+              <stop
+                offset="100%"
+                stopColor={color}
+                stopOpacity={clampValue(connector.to.opacity, 0, 1)}
+              />
+            </linearGradient>
+          );
+        }
+      }
+      return defs;
+    }, [series, scaleX, makeGradientId, showOpacityGradient, resolveDisplayColor]);
+
+    const areaGradients = React.useMemo(() => {
+      const defs: React.ReactNode[] = [];
+      for (const line of series) {
+        const color = resolveDisplayColor(line);
+        const gradientId = makeAreaGradientId(line.topicId);
+        defs.push(
+          <linearGradient key={gradientId} id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={0.32} />
+            <stop offset="100%" stopColor={color} stopOpacity={0} />
+          </linearGradient>
+        );
+      }
+      return defs;
+    }, [series, makeAreaGradientId, resolveDisplayColor]);
+
+    const gradientDefs = React.useMemo(
+      () => [...areaGradients, ...segmentGradients, ...connectorGradients],
+      [areaGradients, segmentGradients, connectorGradients]
+    );
 
     const todayPosition = React.useMemo(() => {
       const now = Date.now();
@@ -446,79 +622,7 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
       return results;
     }, [xDomain, plotWidth, timeZone, axisDayFormatter, axisMonthFormatter]);
 
-    const [tooltip, setTooltip] = React.useState<
-      | null
-      | {
-          x: number;
-          y: number;
-          topic: string;
-          time: number;
-          retention?: number;
-          type?: "started" | "reviewed" | "skipped" | "checkpoint";
-          intervalDays?: number;
-          notes?: string;
-        }
-    >(null);
-    const [markerTooltip, setMarkerTooltip] = React.useState<MarkerTooltip | null>(null);
-
-    const tooltipsSuspendedRef = React.useRef(false);
-
-    const hideTooltip = React.useCallback(() => setTooltip(null), []);
-    const hideMarkerTooltip = React.useCallback(() => setMarkerTooltip(null), []);
-
-    const handlePointerMove: React.PointerEventHandler<SVGRectElement> = (event) => {
-      if (tooltipsSuspendedRef.current) {
-        hideTooltip();
-        hideMarkerTooltip();
-        return;
-      }
-      const { offsetX } = event.nativeEvent;
-      if (offsetX < PADDING_X || offsetX > width - PADDING_X) {
-        hideTooltip();
-        hideMarkerTooltip();
-        return;
-      }
-      const ratio = clampValue((offsetX - PADDING_X) / plotWidth, 0, 1);
-      const time = xDomain[0] + ratio * domainSpan;
-      let best:
-        | null
-        | {
-            series: TimelineSeries;
-            point: { t: number; r: number };
-            distance: number;
-          } = null;
-
-      for (const line of series) {
-        if (line.points.length === 0) continue;
-        let left = 0;
-        let right = line.points.length - 1;
-        while (right - left > 1) {
-          const mid = (left + right) >> 1;
-          if (line.points[mid].t < time) left = mid;
-          else right = mid;
-        }
-        const candidates = [line.points[left], line.points[Math.min(right, line.points.length - 1)]];
-        for (const candidate of candidates) {
-          const x = scaleX(candidate.t);
-          const distance = Math.abs(x - offsetX);
-          if (!best || distance < best.distance) {
-            best = { series: line, point: candidate, distance };
-          }
-        }
-      }
-
-      if (best) {
-        setTooltip({
-          x: scaleX(best.point.t),
-          y: scaleY(best.point.r),
-          topic: best.series.topicTitle,
-          time: best.point.t,
-          retention: best.point.r
-        });
-      } else {
-        hideTooltip();
-      }
-    };
+    const handlePointerMove: React.PointerEventHandler<SVGRectElement> = () => {};
 
     const selectionRef = React.useRef<SelectionState | null>(null);
     const [selectionRect, setSelectionRect] = React.useState<SelectionState | null>(null);
@@ -552,7 +656,6 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
       selectionRef.current = null;
       setSelectionRect(null);
       setSelectionLabel(null);
-      tooltipsSuspendedRef.current = false;
     }, []);
 
     const updateSelectionVisual = React.useCallback(
@@ -651,12 +754,9 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
           originClientX: event.clientX,
           startDomain: xDomain
         };
-        tooltipsSuspendedRef.current = true;
         setIsPanning(true);
-        hideTooltip();
-        hideMarkerTooltip();
       },
-      [hideMarkerTooltip, hideTooltip, xDomain]
+      [xDomain]
     );
 
     const updatePan = React.useCallback(
@@ -675,14 +775,10 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
       [commitViewportChange, domainSpan, fullDomain, onViewportChange, plotWidth, yDomain]
     );
 
-    const endPan = React.useCallback(
-      () => {
-        panStateRef.current = null;
-        setIsPanning(false);
-        tooltipsSuspendedRef.current = false;
-      },
-      []
-    );
+    const endPan = React.useCallback(() => {
+      panStateRef.current = null;
+      setIsPanning(false);
+    }, []);
 
     const shouldPan = React.useCallback(
       (event: React.PointerEvent<SVGRectElement>) => {
@@ -703,10 +799,6 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
       }
 
       (event.target as Element).setPointerCapture(event.pointerId);
-
-      tooltipsSuspendedRef.current = true;
-      hideTooltip();
-      hideMarkerTooltip();
 
       if (event.pointerType === "touch") {
         activeTouchesRef.current.set(event.pointerId, {
@@ -753,9 +845,6 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
               initialSpan: domainSpan,
               pushed: false
             };
-            tooltipsSuspendedRef.current = true;
-            hideTooltip();
-            hideMarkerTooltip();
           } else {
             const session = pinchStateRef.current;
             const ratio = clampValue(distance / session.initialDistance, 0.25, 4);
@@ -802,7 +891,6 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
         activeTouchesRef.current.delete(event.pointerId);
         if (activeTouchesRef.current.size < 2) {
           pinchStateRef.current = null;
-          tooltipsSuspendedRef.current = false;
         }
       }
 
@@ -818,8 +906,6 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
 
     const handlePointerLeave: React.PointerEventHandler<SVGRectElement> = () => {
       cancelSelection();
-      hideTooltip();
-      hideMarkerTooltip();
       endPan();
       pinchStateRef.current = null;
       activeTouchesRef.current.clear();
@@ -830,7 +916,6 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
       endPan();
       pinchStateRef.current = null;
       activeTouchesRef.current.clear();
-      tooltipsSuspendedRef.current = false;
     };
 
     const handleWheel: React.WheelEventHandler<SVGSVGElement> = (event) => {
@@ -872,175 +957,241 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
 
     React.useEffect(() => () => clearWheelSession(), [clearWheelSession]);
 
-    React.useEffect(() => {
-      setMarkerTooltip(null);
-    }, [examMarkers, xDomain]);
-
-    const paths = series.map((line) => (
-      <g key={line.topicId}>
-        {line.segments.map((segment) => {
-          if (segment.points.length === 0) return null;
-          const gradientId = makeGradientId(line.topicId, segment.id);
-          const strokeColor = showOpacityFade ? `url(#${gradientId})` : line.color;
-          return (
-            <path
-              key={segment.id}
-              d={segment.points
-                .map((point, index) => `${index === 0 ? "M" : "L"} ${scaleX(point.t)} ${scaleY(point.r)}`)
-                .join(" ")}
-              fill="none"
-              stroke={strokeColor}
-              strokeWidth={segment.isHistorical ? 1.5 : 2.5}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeOpacity={showOpacityFade ? undefined : 1}
-            />
-          );
-        })}
-        {showReviewLines
-          ? line.stitches.map((stitch) => {
-            const x = scaleX(stitch.t);
-            const yTop = scaleY(Math.min(1, Math.max(yDomain[0], stitch.to)));
-            const yBottom = scaleY(Math.max(yDomain[0], Math.min(yDomain[1], stitch.from)));
-            return (
-              <line
-                key={stitch.id}
-                x1={x}
-                x2={x}
-                y1={yTop}
-                y2={yBottom}
-                stroke={line.color}
-                strokeWidth={1.5}
-                strokeDasharray="2 2"
-                opacity={0.8}
-                pointerEvents="none"
-              />
-            );
-          })
-          : null}
-        {line.events.map((event) => {
-          const x = scaleX(event.t);
-          let yValue = 1;
-          if (event.type === "checkpoint") {
-            const segment = line.segments.find((seg) => seg.checkpoint && seg.checkpoint.t === event.t);
-            if (segment?.checkpoint) {
-              yValue = segment.checkpoint.target;
+    const paths = series.map((line) => {
+      const color = resolveDisplayColor(line);
+      const areaGradientId = makeAreaGradientId(line.topicId);
+      return (
+        <g key={line.topicId}>
+          <g>
+            {line.segments.map((segment) => {
+              if (segment.points.length === 0) return null;
+              const gradientId = makeGradientId(line.topicId, segment.id);
+              const strokeColor = showOpacityGradient ? `url(#${gradientId})` : color;
+              const smooth = createSmoothPaths(segment.points, scaleX, scaleY, baselineY);
+              if (!smooth) return null;
+              return (
+                <React.Fragment key={segment.id}>
+                  {smooth.area ? (
+                    <path
+                      d={smooth.area}
+                      fill={`url(#${areaGradientId})`}
+                      opacity={segment.isHistorical ? 0.45 : 0.7}
+                      pointerEvents="none"
+                    />
+                  ) : null}
+                  <path
+                    d={smooth.line}
+                    fill="none"
+                    stroke={strokeColor}
+                    strokeWidth={segment.isHistorical ? 1.4 : 2.4}
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </React.Fragment>
+              );
+            })}
+            {line.connectors.map((connector) => {
+              const fromX = scaleX(connector.from.t);
+              const fromY = scaleY(connector.from.r);
+              const toX = scaleX(connector.to.t);
+              const toY = scaleY(connector.to.r);
+              const gradientId = makeGradientId(line.topicId, `connector-${connector.id}`);
+              const strokeColor = showOpacityGradient ? `url(#${gradientId})` : color;
+              return (
+                <line
+                  key={connector.id}
+                  x1={fromX}
+                  y1={fromY}
+                  x2={toX}
+                  y2={toY}
+                  stroke={strokeColor}
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                />
+              );
+            })}
+          </g>
+          {showReviewMarkers
+            ? line.stitches.map((stitch) => {
+                const x = scaleX(stitch.t);
+                const yTop = scaleY(Math.min(1, Math.max(yDomain[0], stitch.to)));
+                const yBottom = scaleY(Math.max(yDomain[0], Math.min(yDomain[1], stitch.from)));
+                return (
+                  <line
+                    key={stitch.id}
+                    x1={x}
+                    x2={x}
+                    y1={yTop}
+                    y2={yBottom}
+                    stroke={color}
+                    strokeWidth={1.5}
+                    strokeDasharray="2 2"
+                    opacity={0.7}
+                    pointerEvents="none"
+                  />
+                );
+              })
+            : null}
+          {line.events.map((event) => {
+            const x = scaleX(event.t);
+            let yValue = 1;
+            if (event.type === "checkpoint") {
+              const segment = line.segments.find((seg) => seg.checkpoint && seg.checkpoint.t === event.t);
+              if (segment?.checkpoint) {
+                yValue = segment.checkpoint.target;
+              }
             }
-          }
-          const y = scaleY(Math.max(yDomain[0], Math.min(yDomain[1], yValue)));
-          const handleFocus = () =>
-            setTooltip({
-              x,
-              y: scaleY(Math.min(0.9, yDomain[1])),
-              topic: line.topicTitle,
-              time: event.t,
-              type: event.type,
-              intervalDays: event.intervalDays,
-              notes: event.notes
-            });
-          const transform = `translate(${x}, ${y})`;
-          if (event.type === "started") {
-            return (
-              <rect
-                key={event.id}
-                x={-5}
-                y={-5}
-                width={10}
-                height={10}
-                fill={line.color}
-                tabIndex={0}
-                transform={transform}
-                aria-label={`${line.topicTitle} started ${tooltipDateFormatter.format(new Date(event.t))}`}
-                onFocus={handleFocus}
-                onBlur={hideTooltip}
-                onMouseEnter={handleFocus}
-                onMouseLeave={hideTooltip}
-              />
-            );
-          }
-          if (event.type === "skipped") {
-            return (
-              <polygon
-                key={event.id}
-                points="0,-6 6,0 0,6 -6,0"
-                fill={line.color}
-                tabIndex={0}
-                transform={transform}
-                aria-label={`${line.topicTitle} skipped ${tooltipDateFormatter.format(new Date(event.t))}`}
-                onFocus={handleFocus}
-                onBlur={hideTooltip}
-                onMouseEnter={handleFocus}
-                onMouseLeave={hideTooltip}
-              />
-            );
-          }
-          if (event.type === "checkpoint") {
+            const y = scaleY(Math.max(yDomain[0], Math.min(yDomain[1], yValue)));
+            const transform = `translate(${x}, ${y})`;
+
+            if (event.type === "started") {
+              if (!showEventDots) return null;
+              return (
+                <rect
+                  key={event.id}
+                  x={-5}
+                  y={-5}
+                  width={10}
+                  height={10}
+                  fill={color}
+                  tabIndex={0}
+                  transform={transform}
+                  aria-label={`${line.topicTitle} started ${tooltipDateFormatter.format(new Date(event.t))}`}
+                />
+              );
+            }
+
+            if (!showReviewMarkers) {
+              return null;
+            }
+
+            if (event.type === "skipped") {
+              return (
+                <polygon
+                  key={event.id}
+                  points="0,-6 6,0 0,6 -6,0"
+                  fill={color}
+                  tabIndex={0}
+                  transform={transform}
+                  aria-label={`${line.topicTitle} skipped ${tooltipDateFormatter.format(new Date(event.t))}`}
+                />
+              );
+            }
+
+            if (event.type === "checkpoint") {
+              return (
+                <circle
+                  key={event.id}
+                  r={6}
+                  fill="hsl(var(--inverse))"
+                  stroke={color}
+                  strokeWidth={2}
+                  tabIndex={0}
+                  transform={transform}
+                  aria-label={`${line.topicTitle} checkpoint ${tooltipDateFormatter.format(new Date(event.t))}`}
+                />
+              );
+            }
+
             return (
               <circle
                 key={event.id}
-                r={6}
-                fill="white"
-                stroke={line.color}
-                strokeWidth={2}
+                r={4}
+                fill={color}
                 tabIndex={0}
                 transform={transform}
-                aria-label={`${line.topicTitle} checkpoint ${tooltipDateFormatter.format(new Date(event.t))}`}
-                onFocus={handleFocus}
-                onBlur={hideTooltip}
-                onMouseEnter={handleFocus}
-                onMouseLeave={hideTooltip}
+                aria-label={`${line.topicTitle} reviewed ${tooltipDateFormatter.format(new Date(event.t))}`}
               />
             );
+          })}
+          {line.nowPoint
+            ? (() => {
+                const point = line.nowPoint;
+                if (!point) return null;
+                const x = scaleX(point.t);
+                const y = scaleY(point.r);
+                return (
+                  <g key={`${line.topicId}-now`} transform={`translate(${x}, ${y})`}>
+                    <circle
+                      r={4}
+                      fill={color}
+                      stroke="hsl(var(--inverse))"
+                      strokeWidth={1.5}
+                      tabIndex={0}
+                      aria-label={`${line.topicTitle} retention now ${Math.round(line.nowPoint!.r * 100)}%`}
+                    />
+                  </g>
+                );
+              })()
+            : null}
+        </g>
+      );
+    });
+
+
+    const topicLabels = React.useMemo(
+      () => {
+        if (!showTopicLabels) return [] as { topicId: string; text: string; x: number; y: number }[];
+        const visibleSeries = series.filter(
+          (line) => line.nowPoint && line.nowPoint.t >= xDomain[0] && line.nowPoint.t <= xDomain[1]
+        );
+        if (visibleSeries.length === 0) return [];
+
+        const entries = visibleSeries.map((line) => {
+          const nowPoint = line.nowPoint!;
+          const x = scaleX(nowPoint.t);
+          const y = scaleY(nowPoint.r);
+          const retentionPercent = clampValue(Math.round(nowPoint.r * 100), 0, 100);
+          return {
+            topicId: line.topicId,
+            text: `${line.topicTitle} — ${retentionPercent}%`,
+            x,
+            y
+          };
+        });
+
+        const minY = PADDING_Y;
+        const maxY = height - PADDING_Y;
+        const minGap = 18;
+        const sorted = entries
+          .map((entry) => ({ ...entry }))
+          .sort((a, b) => a.y - b.y);
+
+        for (let index = 0; index < sorted.length; index += 1) {
+          const previous = index > 0 ? sorted[index - 1] : null;
+          const desired = clampValue(sorted[index].y, minY, maxY);
+          const adjusted = previous ? Math.max(desired, previous.y + minGap) : Math.max(minY, desired);
+          sorted[index].y = Math.min(adjusted, maxY);
+        }
+
+        for (let index = sorted.length - 2; index >= 0; index -= 1) {
+          const next = sorted[index + 1];
+          if (next.y - sorted[index].y < minGap) {
+            sorted[index].y = Math.max(minY, next.y - minGap);
           }
-          return (
-            <circle
-              key={event.id}
-              r={5}
-              fill={line.color}
-              tabIndex={0}
-              transform={transform}
-              aria-label={`${line.topicTitle} reviewed ${tooltipDateFormatter.format(new Date(event.t))}`}
-              onFocus={handleFocus}
-              onBlur={hideTooltip}
-              onMouseEnter={handleFocus}
-              onMouseLeave={hideTooltip}
-            />
-          );
-        })}
-        {line.nowPoint && line.nowPoint.t >= xDomain[0] && line.nowPoint.t <= xDomain[1] ? (
-          (() => {
-            const x = scaleX(line.nowPoint!.t);
-            const y = scaleY(line.nowPoint!.r);
-            const handleFocus = () => {
-              setTooltip({
-                x,
-                y: scaleY(Math.min(line.nowPoint!.r + 0.1, yDomain[1])),
-                topic: line.topicTitle,
-                time: line.nowPoint!.t,
-                retention: line.nowPoint!.r,
-                notes: line.nowPoint!.notes
-              });
-            };
-            return (
-              <g key={`${line.topicId}-now`} transform={`translate(${x}, ${y})`}>
-                <circle
-                  r={4}
-                  fill={line.color}
-                  stroke="white"
-                  strokeWidth={1.5}
-                  tabIndex={0}
-                  aria-label={`${line.topicTitle} retention now ${Math.round(line.nowPoint!.r * 100)}%`}
-                  onFocus={handleFocus}
-                  onBlur={hideTooltip}
-                  onMouseEnter={handleFocus}
-                  onMouseLeave={hideTooltip}
-                />
-              </g>
-            );
-          })()
-        ) : null}
-      </g>
-    ));
+        }
+
+        const labelXBase = todayPosition ?? sorted[0]?.x ?? PADDING_X;
+        const xPosition = clampValue(labelXBase + 8, PADDING_X + 4, width - PADDING_X + 40);
+
+        return sorted.map((entry) => ({
+          topicId: entry.topicId,
+          text: entry.text,
+          x: xPosition,
+          y: clampValue(entry.y, minY, maxY)
+        }));
+      },
+      [
+        showTopicLabels,
+        series,
+        xDomain,
+        scaleX,
+        scaleY,
+        todayPosition,
+        height,
+        width
+      ]
+    );
 
     const clampX = React.useCallback(
       (value: number) => clampValue(value, PADDING_X, width - PADDING_X),
@@ -1080,7 +1231,6 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
           const horizontalOffset = (index - (cluster.items.length - 1) / 2) * 6;
           const x = clampX(marker.x + horizontalOffset);
           const labelY = Math.max(12, PADDING_Y - 18 - index * 16);
-          const tooltipY = Math.max(8, labelY - 24);
           markerGraphics.push(
             <line
               key={`${marker.id}-line`}
@@ -1094,34 +1244,16 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
               opacity={0.85}
             />
           );
-          const tooltipItems = [
-            {
-              subjectName: marker.subjectName,
-              dateISO: marker.dateISO,
-              daysRemaining: marker.daysRemaining,
-              color: marker.color
-            }
-          ];
-          const handleFocus = () =>
-            setMarkerTooltip({
-              x,
-              y: tooltipY,
-              items: tooltipItems
-            });
           markerGraphics.push(
             <g
               key={`${marker.id}-label`}
               transform={`translate(${x}, ${labelY})`}
               tabIndex={0}
-              role="button"
+              role="img"
               aria-label={`Exam date for ${marker.subjectName}, ${examDateFormatter.format(new Date(marker.dateISO))}`}
-              onFocus={handleFocus}
-              onBlur={hideMarkerTooltip}
-              onMouseEnter={handleFocus}
-              onMouseLeave={hideMarkerTooltip}
             >
               <foreignObject x={-80} y={-18} width={160} height={26}>
-                <div className="pointer-events-none flex items-center gap-1 rounded-full bg-slate-900/90 px-3 py-1 text-[10px] font-medium text-white shadow-lg">
+                <div className="pointer-events-none flex items-center gap-1 rounded-full bg-card/90 px-3 py-1 text-[10px] font-medium text-fg shadow-lg">
                   <span className="inline-flex h-2 w-2 rounded-full" style={{ backgroundColor: marker.color }} />
                   <span className="uppercase text-[9px] tracking-wide text-accent">Exam</span>
                   <span className="max-w-[90px] truncate">{marker.subjectName}</span>
@@ -1154,35 +1286,16 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
       const clusterX = clampX(cluster.x);
       const labelY = Math.max(12, PADDING_Y - 22);
       const label = `${cluster.items.length} exams`;
-      const tooltipY = Math.max(8, labelY - 24);
-      const tooltipItems = cluster.items.map((item) => ({
-        subjectName: item.subjectName,
-        dateISO: item.dateISO,
-        daysRemaining: item.daysRemaining,
-        color: item.color
-      }));
-      const handleClusterFocus = () =>
-        setMarkerTooltip({
-          x: clusterX,
-          y: tooltipY,
-          title: "Upcoming exams",
-          items: tooltipItems
-        });
-
       markerGraphics.push(
         <g
           key={`cluster-${clusterIndex}`}
           transform={`translate(${clusterX}, ${labelY})`}
           tabIndex={0}
-          role="button"
+          role="img"
           aria-label={`Upcoming exams: ${cluster.items.map((item) => item.subjectName).join(", ")}`}
-          onFocus={handleClusterFocus}
-          onBlur={hideMarkerTooltip}
-          onMouseEnter={handleClusterFocus}
-          onMouseLeave={hideMarkerTooltip}
         >
           <foreignObject x={-70} y={-18} width={140} height={26}>
-            <div className="pointer-events-none flex items-center justify-center rounded-full bg-slate-900/90 px-3 py-1 text-[10px] font-semibold text-white shadow-lg">
+            <div className="pointer-events-none flex items-center justify-center rounded-full bg-card/90 px-3 py-1 text-[10px] font-semibold text-fg shadow-lg">
               {label}
             </div>
           </foreignObject>
@@ -1230,7 +1343,7 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
           }}
           style={{ cursor }}
         >
-          {segmentGradients.length > 0 ? <defs>{segmentGradients}</defs> : null}
+          {gradientDefs.length > 0 ? <defs>{gradientDefs}</defs> : null}
           <rect width={width} height={height} fill="transparent" />
           <rect
             x={PADDING_X}
@@ -1249,7 +1362,7 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
             onDoubleClick={() => onResetDomain?.()}
           />
           {showGrid ? (
-            <g className="stroke-white/10">
+            <g>
               {yTicks.map((tick) => (
                 <g key={tick.value}>
                   <line
@@ -1257,12 +1370,14 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
                     y1={tick.pixel}
                     x2={width - PADDING_X}
                     y2={tick.pixel}
-                    className="stroke-white/10"
+                    stroke="hsl(var(--grid))"
+                    strokeOpacity={0.35}
                   />
                   <text
                     x={12}
                     y={tick.pixel + 4}
-                    className="fill-white/50 text-[10px]"
+                    fill="hsl(var(--axis))"
+                    className="text-[10px]"
                   >
                     {tick.label}
                   </text>
@@ -1276,17 +1391,19 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
               y1={height - PADDING_Y}
               x2={width - PADDING_X}
               y2={height - PADDING_Y}
-              className="stroke-white/15"
+              stroke="hsl(var(--grid))"
+              strokeOpacity={0.35}
             />
             {ticks.map((tick) => {
               const x = scaleX(tick.time);
               return (
                 <g key={tick.time} transform={`translate(${x}, ${height - PADDING_Y})`}>
-                  <line y1={0} y2={6} className="stroke-white/30" />
+                  <line y1={0} y2={6} stroke="hsl(var(--grid))" strokeOpacity={0.45} />
                   <text
                     y={18}
                     textAnchor="middle"
-                    className="fill-white/60 text-[10px]"
+                    fill="hsl(var(--axis))"
+                    className="text-[10px]"
                   >
                     {tick.label}
                   </text>
@@ -1301,13 +1418,15 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
                 x2={todayPosition}
                 y1={PADDING_Y}
                 y2={height - PADDING_Y}
-                className="stroke-red-400/70"
+                stroke="hsl(var(--accent))"
+                strokeOpacity={0.7}
                 strokeWidth={1.5}
               />
               <text
                 x={todayPosition + 4}
                 y={PADDING_Y + 12}
-                className="fill-red-200 text-[10px]"
+                fill="hsl(var(--accent) / 0.5)"
+                className="text-[10px]"
               >
                 Today
               </text>
@@ -1315,7 +1434,30 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
           )}
           {markerGraphics}
           {paths}
-          <text x={12} y={16} className="fill-white/40 text-[11px]">
+          {topicLabels.length > 0 ? (
+            <g aria-hidden="true">
+              {topicLabels.map((label) => (
+                <text
+                  key={`topic-label-${label.topicId}`}
+                  x={label.x}
+                  y={label.y}
+                  textAnchor="start"
+                  dominantBaseline="middle"
+                  fill="currentColor"
+                  stroke="hsl(var(--bg))"
+                  strokeOpacity={0.75}
+                  strokeWidth={3}
+                  style={{ paintOrder: "stroke fill" }}
+                  className="text-inverse"
+                  fontSize={12}
+                  fontWeight={600}
+                >
+                  {label.text}
+                </text>
+              ))}
+            </g>
+          ) : null}
+          <text x={12} y={16} fill="hsl(var(--axis))" className="text-[11px]">
             Retention
           </text>
           {keyboardOverlay ? (
@@ -1324,8 +1466,8 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
               y={keyboardOverlay.y}
               width={keyboardOverlay.width}
               height={keyboardOverlay.height}
-              fill="rgba(56,189,248,0.12)"
-              stroke="rgba(56,189,248,0.7)"
+              fill="hsl(var(--accent) / 0.12)"
+              stroke="hsl(var(--accent) / 0.7)"
               strokeDasharray="6 4"
               pointerEvents="none"
             />
@@ -1337,8 +1479,8 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
                 y={Math.min(selectionRect.origin.y, selectionRect.current.y)}
                 width={Math.abs(selectionRect.current.x - selectionRect.origin.x)}
                 height={Math.abs(selectionRect.current.y - selectionRect.origin.y)}
-                fill="rgba(56,189,248,0.15)"
-                stroke="rgba(56,189,248,0.8)"
+                fill="hsl(var(--accent) / 0.15)"
+                stroke="hsl(var(--accent) / 0.8)"
                 strokeDasharray="6 4"
               />
               {selectionLabel ? (
@@ -1348,72 +1490,16 @@ export const TimelineChart = React.forwardRef<SVGSVGElement, TimelineChartProps>
                   width={220}
                   height={64}
                 >
-                  <div className="pointer-events-none rounded-md bg-slate-950/80 px-3 py-2 text-[11px] text-white shadow-lg">
+                  <div className="pointer-events-none rounded-md bg-bg/80 px-3 py-2 text-[11px] text-fg shadow-lg">
                     <div className="font-semibold">{selectionLabel.primary}</div>
                     {selectionRect.shift && selectionLabel.secondary ? (
-                      <div className="text-[10px] text-sky-200">{selectionLabel.secondary}</div>
+                      <div className="text-[10px] text-accent/20">{selectionLabel.secondary}</div>
                     ) : null}
                   </div>
                 </foreignObject>
               ) : null}
             </g>
           ) : null}
-          {tooltip && (
-            <g transform={`translate(${tooltip.x}, ${tooltip.y})`} className="pointer-events-none">
-              <circle r={4} fill="#fff" />
-              <foreignObject x={8} y={-4} width={220} height={96}>
-                <div className="rounded-md bg-zinc-900/90 p-2 text-xs text-white shadow-lg">
-                  <div className="font-semibold" style={{ color: tooltip.type ? undefined : "inherit" }}>
-                    {tooltip.topic}
-                  </div>
-                  <div>{tooltipDateFormatter.format(new Date(tooltip.time))}</div>
-                  {typeof tooltip.retention !== "undefined" && (
-                    <div>Retention: {Math.round(tooltip.retention * 100)}%</div>
-                  )}
-                  {tooltip.type && (
-                    <div>
-                      Event: {tooltip.type === "started"
-                        ? "Started"
-                        : tooltip.type === "skipped"
-                        ? "Skipped"
-                        : tooltip.type === "checkpoint"
-                        ? "Checkpoint"
-                        : "Reviewed"}
-                    </div>
-                  )}
-                  {typeof tooltip.intervalDays !== "undefined" && (
-                    <div>Interval: {tooltip.intervalDays} day{tooltip.intervalDays === 1 ? "" : "s"}</div>
-                  )}
-                  {tooltip.notes && <div className="text-[11px] text-zinc-300">Notes: {tooltip.notes}</div>}
-                </div>
-              </foreignObject>
-            </g>
-          )}
-          {markerTooltip && (
-            <g transform={`translate(${markerTooltip.x}, ${markerTooltip.y})`} className="pointer-events-none">
-              <foreignObject x={8} y={-4} width={240} height={Math.max(80, markerTooltip.items.length * 36 + 20)}>
-                <div className="rounded-md bg-zinc-900/95 p-3 text-xs text-white shadow-lg">
-                  {markerTooltip.title ? (
-                    <div className="mb-1 font-semibold text-white">{markerTooltip.title}</div>
-                  ) : null}
-                  {markerTooltip.items.map((item) => {
-                    const days = item.daysRemaining ?? 0;
-                    const dayLabel = days === 0 ? "Exam today" : `${days} day${days === 1 ? "" : "s"} left`;
-                    return (
-                      <div key={`${item.subjectName}-${item.dateISO}`} className="mb-2 last:mb-0">
-                        <div className="flex items-center gap-2">
-                          <span className="inline-flex h-2.5 w-2.5 rounded-full" style={{ backgroundColor: item.color }} />
-                          <span className="font-semibold">{item.subjectName}</span>
-                        </div>
-                        <div className="text-[11px] text-zinc-300">{examDateFormatter.format(new Date(item.dateISO))}</div>
-                        <div className="text-[11px] text-zinc-400">{dayLabel}</div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </foreignObject>
-            </g>
-          )}
         </svg>
       </div>
     );

--- a/src/components/visualizations/timeline-panel.tsx
+++ b/src/components/visualizations/timeline-panel.tsx
@@ -15,12 +15,14 @@ import { downloadSvg, downloadSvgAsPng } from "@/lib/export-svg";
 import { buildCurveSegments, sampleSegment } from "@/selectors/curves";
 import { useTopicStore } from "@/stores/topics";
 import { useProfileStore } from "@/stores/profile";
+import { useTimelinePreferencesStore } from "@/stores/timeline-preferences";
 import { Subject, Topic } from "@/types/topic";
 import { SubjectFilterValue, NO_SUBJECT_KEY } from "@/components/dashboard/topic-list";
 import {
   CalendarClock,
   Check,
   Droplet,
+  Dot,
   EllipsisVertical,
   Eye,
   EyeOff,
@@ -37,7 +39,8 @@ import {
   Hand,
   SquareDashedMousePointer,
   Maximize2,
-  Minimize2
+  Minimize2,
+  Type
 } from "lucide-react";
 import {
   daysBetween,
@@ -51,6 +54,7 @@ import {
   STABILITY_MIN_DAYS,
   computeRetrievability
 } from "@/lib/forgetting-curve";
+import { FALLBACK_SUBJECT_COLOR, generateTopicColorMap } from "@/lib/colors";
 
 const DEFAULT_WINDOW_DAYS = 30;
 const MIN_ZOOM_SPAN = DAY_MS;
@@ -122,6 +126,7 @@ const deriveSeries = (
       color,
       points: [],
       segments: [],
+      connectors: [],
       stitches: [],
       events: [
         {
@@ -214,6 +219,37 @@ const deriveSeries = (
               ? `Reviewed → next interval ${(segment.start.intervalDays ?? 0).toFixed(2)} days`
               : undefined
         });
+
+        if (Number.isFinite(prevStart)) {
+          const intervalMs = Math.max(0, reviewTime - prevStart);
+          const epsilonMs = Math.max(60_000, Math.min(intervalMs * 0.1, 12 * 60 * 60 * 1000));
+          const connectorStartTime = Math.max(prevStart, reviewTime - epsilonMs);
+          const connectorElapsed = Math.max(0, connectorStartTime - prevStart);
+          const connectorRetention = computeRetrievability(
+            previousRenderableSegment.stabilityDays,
+            connectorElapsed
+          );
+          const nowSpan = nowMs - prevStart;
+          const computeOpacity = (timestamp: number) => {
+            if (!Number.isFinite(timestamp)) return 0;
+            if (nowSpan <= 0) {
+              return timestamp >= prevStart ? 1 : 0;
+            }
+            const ratio = (timestamp - prevStart) / nowSpan;
+            return Math.max(0, Math.min(1, ratio));
+          };
+          if (connectorStartTime < reviewTime) {
+            pack.connectors.push({
+              id: `connector-${segment.start.id}`,
+              from: {
+                t: connectorStartTime,
+                r: connectorRetention,
+                opacity: computeOpacity(connectorStartTime)
+              },
+              to: { t: reviewTime, r: 1, opacity: 1 }
+            });
+          }
+        }
       }
 
       if (hasSamples) {
@@ -252,6 +288,7 @@ const deriveSeries = (
     pack.points.sort((a, b) => a.t - b.t);
     pack.events.sort((a, b) => a.t - b.t);
     pack.stitches.sort((a, b) => a.t - b.t);
+    pack.connectors.sort((a, b) => a.from.t - b.from.t);
     series.push(pack);
   }
 
@@ -412,10 +449,13 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
     return map;
   }, [storeSubjects]);
 
-  const resolveTopicColor = React.useCallback(
-    (topic: Topic) => {
-      const subject = topic.subjectId ? subjectLookup.get(topic.subjectId) : undefined;
-      return subject?.color ?? "#7c3aed";
+  const resolveSubjectColor = React.useCallback(
+    (subjectId: string | null | undefined) => {
+      if (!subjectId) {
+        return FALLBACK_SUBJECT_COLOR;
+      }
+      const subject = subjectLookup.get(subjectId);
+      return subject?.color ?? FALLBACK_SUBJECT_COLOR;
     },
     [subjectLookup]
   );
@@ -440,8 +480,14 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
   const [hasStudyActivity, setHasStudyActivity] = React.useState(true);
   const [showExamMarkers, setShowExamMarkers] = React.useState(true);
   const [showCheckpoints, setShowCheckpoints] = React.useState(false);
-  const [showOpacityFade, setShowOpacityFade] = React.useState(true);
-  const [showReviewMarkers, setShowReviewMarkers] = React.useState(false);
+  const showOpacityGradient = useTimelinePreferencesStore((state) => state.showOpacityGradient);
+  const setShowOpacityGradient = useTimelinePreferencesStore((state) => state.setShowOpacityGradient);
+  const showReviewMarkers = useTimelinePreferencesStore((state) => state.showReviewMarkers);
+  const setShowReviewMarkers = useTimelinePreferencesStore((state) => state.setShowReviewMarkers);
+  const showEventDots = useTimelinePreferencesStore((state) => state.showEventDots);
+  const setShowEventDots = useTimelinePreferencesStore((state) => state.setShowEventDots);
+  const showTopicLabels = useTimelinePreferencesStore((state) => state.showTopicLabels);
+  const setShowTopicLabels = useTimelinePreferencesStore((state) => state.setShowTopicLabels);
   const svgRef = React.useRef<SVGSVGElement | null>(null);
   const perSubjectSvgRefs = React.useRef(new Map<string, SVGSVGElement | null>());
   const perSubjectContainerRef = React.useRef<HTMLDivElement | null>(null);
@@ -785,6 +831,38 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
     return sorted;
   }, [topics, categoryFilter, search, sortView]);
 
+  const singleSubjectColorOverrides = React.useMemo(() => {
+    if (filteredTopics.length === 0) return null;
+    const uniqueSubjectKeys = new Set(
+      filteredTopics.map((topic) => topic.subjectId ?? DEFAULT_SUBJECT_ID)
+    );
+    if (uniqueSubjectKeys.size !== 1) return null;
+    const [singleKey] = Array.from(uniqueSubjectKeys);
+    const subjectId = singleKey === DEFAULT_SUBJECT_ID ? null : singleKey;
+    const baseColor = resolveSubjectColor(subjectId);
+    return generateTopicColorMap(baseColor, filteredTopics);
+  }, [filteredTopics, resolveSubjectColor]);
+
+  const singleSubjectLegend = React.useMemo(() => {
+    if (!singleSubjectColorOverrides || singleSubjectColorOverrides.size <= 1) {
+      return null;
+    }
+    const sorted = filteredTopics
+      .filter((topic) => singleSubjectColorOverrides.has(topic.id))
+      .sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: "base" }));
+    if (sorted.length <= 1) return null;
+    const limit = 14;
+    const visible = sorted.slice(0, limit);
+    const remaining = sorted.length - visible.length;
+    return { visible, remaining };
+  }, [filteredTopics, singleSubjectColorOverrides]);
+
+  const resolveTopicColor = React.useCallback(
+    (topic: Topic) =>
+      singleSubjectColorOverrides?.get(topic.id) ?? resolveSubjectColor(topic.subjectId),
+    [singleSubjectColorOverrides, resolveSubjectColor]
+  );
+
   const [nowMs, setNowMs] = React.useState(() => Date.now());
 
   React.useEffect(() => {
@@ -810,21 +888,29 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
     }
     const items: SubjectSeriesGroup[] = [];
     for (const [subjectId, list] of grouped) {
-      const subject = subjectLookup.get(subjectId) ?? null;
-      const derived = deriveSeries(list, visibility, resolveTopicColor, nowMs, showCheckpoints);
+      const actualSubjectId = subjectId === DEFAULT_SUBJECT_ID ? null : subjectId;
+      const subject = actualSubjectId ? subjectLookup.get(actualSubjectId) ?? null : null;
+      const baseColor = resolveSubjectColor(actualSubjectId);
+      const palette = generateTopicColorMap(baseColor, list);
+      const derived = deriveSeries(
+        list,
+        visibility,
+        (topic) => palette.get(topic.id) ?? resolveSubjectColor(topic.subjectId),
+        nowMs,
+        showCheckpoints
+      );
       if (derived.length === 0) continue;
-      const color = subject?.color ?? resolveTopicColor(list[0]);
       items.push({
         subjectId,
         subject,
         label: subject?.name ?? "Unassigned",
-        color,
+        color: baseColor,
         series: derived
       });
     }
     items.sort((a, b) => a.label.localeCompare(b.label));
     return items;
-  }, [filteredTopics, subjectLookup, visibility, resolveTopicColor, nowMs, showCheckpoints]);
+  }, [filteredTopics, subjectLookup, visibility, resolveSubjectColor, nowMs, showCheckpoints]);
 
   React.useEffect(() => {
     if (!fullscreenTarget) return;
@@ -913,7 +999,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
         return {
           id: `exam-marker-${subject.id}`,
           time: examDate.getTime(),
-          color: subject.color ?? "#38bdf8",
+          color: subject.color ?? "hsl(var(--accent))",
           subjectName: subject.name,
           daysRemaining,
           dateISO: examDate.toISOString()
@@ -973,8 +1059,10 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
             onRequestStepBack={handleStepBack}
             onTooSmallSelection={handleTooSmallSelection}
             keyboardSelection={keyboardSelection}
-            showOpacityFade={showOpacityFade}
-            showReviewLines={showReviewMarkers}
+            showOpacityGradient={showOpacityGradient}
+            showReviewMarkers={showReviewMarkers}
+            showEventDots={showEventDots}
+            showTopicLabels={showTopicLabels}
           />
         )
       } as const;
@@ -1007,8 +1095,10 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
           onRequestStepBack={handleStepBack}
           onTooSmallSelection={handleTooSmallSelection}
           keyboardSelection={keyboardSelection}
-          showOpacityFade={showOpacityFade}
-          showReviewLines={showReviewMarkers}
+          showOpacityGradient={showOpacityGradient}
+          showReviewMarkers={showReviewMarkers}
+          showEventDots={showEventDots}
+          showTopicLabels={showTopicLabels}
         />
       )
     } as const;
@@ -1032,8 +1122,10 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
     keyboardSelection,
     perSubjectSeries,
     examMarkersBySubject,
-    showOpacityFade,
-    showReviewMarkers
+    showOpacityGradient,
+    showReviewMarkers,
+    showEventDots,
+    showTopicLabels
   ]);
 
   const isFullscreenOpen = Boolean(fullscreenConfig);
@@ -1124,8 +1216,8 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
   };
 
   const cardClasses = variant === "compact"
-    ? "rounded-3xl border border-white/5 bg-slate-900/50 p-5 shadow-lg shadow-slate-900/30"
-    : "rounded-3xl border border-white/5 bg-slate-900/40 p-6 md:p-8 shadow-xl shadow-slate-900/30";
+    ? "rounded-3xl border border-inverse/5 bg-card/50 p-5 shadow-lg shadow-slate-900/30"
+    : "rounded-3xl border border-inverse/5 bg-card/40 p-6 md:p-8 shadow-xl shadow-slate-900/30";
 
   return (
     <>
@@ -1136,25 +1228,25 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
           <div className="inline-flex items-center gap-2 rounded-full bg-accent/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-accent">
             <Sparkles className="h-3 w-3" /> Retention & schedule
           </div>
-          <h2 className="mt-2 text-xl font-semibold text-white">Review timeline</h2>
-          <p className="text-sm text-zinc-400">
+          <h2 className="mt-2 text-xl font-semibold text-fg">Review timeline</h2>
+          <p className="text-sm text-muted-foreground">
             Track when each topic is due and how its memory curve evolves.
           </p>
         </div>
         <div className="ml-auto flex flex-wrap items-center gap-2">
           <div
-            className="flex items-center gap-1 rounded-2xl border border-white/10 bg-slate-900/60 p-1"
+            className="flex items-center gap-1 rounded-2xl border border-inverse/10 bg-card/60 p-1"
             role="group"
             aria-label="Timeline view mode"
           >
-            <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-zinc-400">
+            <span className="px-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
               View:
             </span>
             <Button
               type="button"
               size="sm"
               variant={viewMode === "combined" ? "default" : "ghost"}
-              className={`rounded-xl px-3 ${viewMode === "combined" ? "bg-accent/20 text-white" : "text-zinc-300"}`}
+              className={`rounded-xl px-3 ${viewMode === "combined" ? "bg-accent/20 text-fg" : "text-muted-foreground"}`}
               onClick={() => setViewMode("combined")}
               aria-pressed={viewMode === "combined"}
             >
@@ -1164,7 +1256,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
               type="button"
               size="sm"
               variant={viewMode === "per-subject" ? "default" : "ghost"}
-              className={`rounded-xl px-3 ${viewMode === "per-subject" ? "bg-accent/20 text-white" : "text-zinc-300"}`}
+              className={`rounded-xl px-3 ${viewMode === "per-subject" ? "bg-accent/20 text-fg" : "text-muted-foreground"}`}
               onClick={() => setViewMode("per-subject")}
               aria-pressed={viewMode === "per-subject"}
             >
@@ -1172,7 +1264,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
             </Button>
           </div>
           <div
-            className="flex items-center gap-1 rounded-2xl border border-white/10 bg-slate-900/60 p-1"
+            className="flex items-center gap-1 rounded-2xl border border-inverse/10 bg-card/60 p-1"
             role="group"
             aria-label="Timeline zoom controls"
             aria-describedby="timeline-zoom-shortcuts"
@@ -1212,7 +1304,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
             </Button>
           </div>
           <div
-            className="flex items-center gap-1 rounded-2xl border border-white/10 bg-slate-900/60 p-1"
+            className="flex items-center gap-1 rounded-2xl border border-inverse/10 bg-card/60 p-1"
             role="group"
             aria-label="Interaction mode"
           >
@@ -1220,7 +1312,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
               type="button"
               size="sm"
               variant={interactionMode === "zoom" ? "default" : "ghost"}
-              className={`inline-flex items-center gap-1 rounded-xl px-3 ${interactionMode === "zoom" ? "bg-accent/20 text-white" : "text-zinc-300"}`}
+              className={`inline-flex items-center gap-1 rounded-xl px-3 ${interactionMode === "zoom" ? "bg-accent/20 text-fg" : "text-muted-foreground"}`}
               onClick={() => setInteractionMode("zoom")}
               aria-pressed={interactionMode === "zoom"}
               title="Zoom select (Z)"
@@ -1232,7 +1324,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
               type="button"
               size="sm"
               variant={interactionMode === "pan" ? "default" : "ghost"}
-              className={`inline-flex items-center gap-1 rounded-xl px-3 ${interactionMode === "pan" ? "bg-accent/20 text-white" : "text-zinc-300"}`}
+              className={`inline-flex items-center gap-1 rounded-xl px-3 ${interactionMode === "pan" ? "bg-accent/20 text-fg" : "text-muted-foreground"}`}
               onClick={() => {
                 setInteractionMode("pan");
                 setKeyboardSelection(null);
@@ -1243,32 +1335,6 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
               <Hand className="h-4 w-4" />
               Pan (Space)
             </Button>
-          </div>
-          <div
-            className="flex items-center gap-1 rounded-2xl border border-white/10 bg-slate-900/60 p-1"
-            role="group"
-            aria-label="Timeline display options"
-          >
-            <Toggle
-              type="button"
-              pressed={showOpacityFade}
-              onPressedChange={(pressed) => setShowOpacityFade(Boolean(pressed))}
-              aria-label="Toggle opacity fade"
-              title="Toggle opacity fade"
-            >
-              <Droplet className="h-3.5 w-3.5" />
-              <span>Opacity fade</span>
-            </Toggle>
-            <Toggle
-              type="button"
-              pressed={showReviewMarkers}
-              onPressedChange={(pressed) => setShowReviewMarkers(Boolean(pressed))}
-              aria-label="Toggle review markers"
-              title="Toggle review markers"
-            >
-              <EllipsisVertical className="h-3.5 w-3.5" />
-              <span>Review markers</span>
-            </Toggle>
           </div>
           <Button
             size="sm"
@@ -1323,15 +1389,15 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
       </p>
 
       {isZoomed ? (
-        <div className="flex flex-wrap items-center gap-2 text-xs text-amber-100" aria-live="polite">
-          <span className="inline-flex items-center gap-2 rounded-full bg-amber-500/15 px-3 py-1 text-[10px] font-semibold uppercase tracking-wide">
+        <div className="flex flex-wrap items-center gap-2 text-xs text-warn/20" aria-live="polite">
+          <span className="inline-flex items-center gap-2 rounded-full bg-warn/15 px-3 py-1 text-[10px] font-semibold uppercase tracking-wide">
             Zoomed
           </span>
           <span>Use Back to step out or reset to return to the full schedule.</span>
           <button
             type="button"
             onClick={handleResetDomain}
-            className="font-semibold text-amber-200 underline-offset-2 hover:underline"
+            className="font-semibold text-warn/30 underline-offset-2 hover:underline"
           >
             Reset view
           </button>
@@ -1339,14 +1405,14 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
       ) : null}
 
       <div className="flex flex-wrap items-center gap-3">
-        <div className="flex items-center gap-2 rounded-2xl border border-white/10 bg-slate-900/60 px-3 py-2 text-xs text-zinc-300">
+        <div className="flex items-center gap-2 rounded-2xl border border-inverse/10 bg-card/60 px-3 py-2 text-xs text-muted-foreground">
           <CalendarClock className="h-3.5 w-3.5" />
           <span>Window (days)</span>
           <Input
             type="number"
             min={7}
             max={365}
-            className="h-8 w-20 border-none bg-transparent text-xs text-white focus-visible:ring-0"
+            className="h-8 w-20 border-none bg-transparent text-xs text-fg focus-visible:ring-0"
             value={domain ? Math.max(7, Math.round((domain[1] - domain[0]) / DAY_MS)) : ""}
             onChange={(event) => {
               if (!domain) return;
@@ -1363,17 +1429,17 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
             disabled={!domain}
           />
         </div>
-        <div className="flex items-center gap-2 rounded-2xl border border-white/10 bg-slate-900/60 px-3 py-2">
-          <Search className="h-3.5 w-3.5 text-zinc-500" />
+        <div className="flex items-center gap-2 rounded-2xl border border-inverse/10 bg-card/60 px-3 py-2">
+          <Search className="h-3.5 w-3.5 text-muted-foreground/80" />
           <Input
             value={search}
             onChange={(event) => setSearch(event.target.value)}
             placeholder="Search topics"
-            className="h-8 w-52 border-none bg-transparent text-xs text-white placeholder:text-zinc-500 focus-visible:ring-0"
+            className="h-8 w-52 border-none bg-transparent text-xs text-fg placeholder:text-muted-foreground/80 focus-visible:ring-0"
           />
         </div>
         <Select value={sortView} onValueChange={(value: SortView) => setSortView(value)}>
-          <SelectTrigger className="h-9 rounded-2xl border-white/10 bg-slate-900/60 text-xs text-white">
+          <SelectTrigger className="h-9 rounded-2xl border-inverse/10 bg-card/60 text-xs text-fg">
             <SelectValue placeholder="Sort" />
           </SelectTrigger>
           <SelectContent className="rounded-2xl backdrop-blur">
@@ -1381,28 +1447,72 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
             <SelectItem value="title">Topic name</SelectItem>
           </SelectContent>
         </Select>
-        <button
-          type="button"
-          onClick={() => setShowExamMarkers((prev) => !prev)}
-          className={`inline-flex items-center gap-2 rounded-2xl border px-3 py-2 text-xs transition ${
-            showExamMarkers
-              ? "border-accent/40 bg-accent/20 text-white"
-              : "border-white/10 bg-transparent text-zinc-400 hover:text-white"
-          }`}
+        <div
+          className="flex flex-wrap items-center gap-1 rounded-2xl border border-inverse/10 bg-card/60 p-1"
+          role="group"
+          aria-label="Timeline overlays"
         >
-          <CalendarClock className="h-3.5 w-3.5" /> Exam markers {showExamMarkers ? "on" : "off"}
-        </button>
-        <button
-          type="button"
-          onClick={() => setShowCheckpoints((prev) => !prev)}
-          className={`inline-flex items-center gap-2 rounded-2xl border px-3 py-2 text-xs transition ${
-            showCheckpoints
-              ? "border-accent/40 bg-accent/20 text-white"
-              : "border-white/10 bg-transparent text-zinc-400 hover:text-white"
-          }`}
-        >
-          <Milestone className="h-3.5 w-3.5" /> Checkpoints {showCheckpoints ? "on" : "off"}
-        </button>
+          <Toggle
+            type="button"
+            pressed={showExamMarkers}
+            onPressedChange={(pressed) => setShowExamMarkers(Boolean(pressed))}
+            aria-label="Toggle exam markers"
+            title="Toggle exam markers"
+          >
+            <CalendarClock className="h-3.5 w-3.5" />
+            <span>Exam Markers</span>
+          </Toggle>
+          <Toggle
+            type="button"
+            pressed={showCheckpoints}
+            onPressedChange={(pressed) => setShowCheckpoints(Boolean(pressed))}
+            aria-label="Toggle checkpoints"
+            title="Toggle checkpoints"
+          >
+            <Milestone className="h-3.5 w-3.5" />
+            <span>Checkpoints</span>
+          </Toggle>
+          <Toggle
+            type="button"
+            pressed={showReviewMarkers}
+            onPressedChange={(pressed) => setShowReviewMarkers(Boolean(pressed))}
+            aria-label="Toggle review markers"
+            title="Toggle review markers"
+          >
+            <EllipsisVertical className="h-3.5 w-3.5" />
+            <span>Review Markers</span>
+          </Toggle>
+          <Toggle
+            type="button"
+            pressed={showEventDots}
+            onPressedChange={(pressed) => setShowEventDots(Boolean(pressed))}
+            aria-label="Toggle event start dots"
+            title="Toggle event start dots"
+          >
+            <Dot className="h-3.5 w-3.5" />
+            <span>Event Dots</span>
+          </Toggle>
+          <Toggle
+            type="button"
+            pressed={showOpacityGradient}
+            onPressedChange={(pressed) => setShowOpacityGradient(Boolean(pressed))}
+            aria-label="Toggle opacity gradient"
+            title="Toggle opacity gradient"
+          >
+            <Droplet className="h-3.5 w-3.5" />
+            <span>Opacity Gradient</span>
+          </Toggle>
+          <Toggle
+            type="button"
+            pressed={showTopicLabels}
+            onPressedChange={(pressed) => setShowTopicLabels(Boolean(pressed))}
+            aria-label="Toggle topic labels"
+            title="Toggle topic labels"
+          >
+            <Type className="h-3.5 w-3.5" />
+            <span>Topic Labels</span>
+          </Toggle>
+        </div>
         {categoryFilter.size > 0 ? (
           <Button size="sm" variant="ghost" onClick={() => setCategoryFilter(new Set())}>
             Clear categories
@@ -1420,8 +1530,8 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
               onClick={() => handleToggleCategory(category.id)}
               className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs transition ${
                 active
-                  ? "border-white/40 bg-white/10 text-white"
-                  : "border-white/10 bg-transparent text-zinc-400 hover:text-white"
+                  ? "border-inverse/40 bg-inverse/10 text-fg"
+                  : "border-inverse/10 bg-transparent text-muted-foreground hover:text-fg"
               }`}
             >
               <span className="inline-flex h-2.5 w-2.5 rounded-full" style={{ backgroundColor: category.color }} />
@@ -1430,18 +1540,18 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
           );
         })}
         {categories.length === 0 ? (
-          <p className="text-xs text-zinc-500">Categories you create appear here for quick filtering.</p>
+          <p className="text-xs text-muted-foreground/80">Categories you create appear here for quick filtering.</p>
         ) : null}
       </div>
 
       {rangeWarning ? (
-        <div className="flex items-center gap-2 rounded-2xl border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
+        <div className="flex items-center gap-2 rounded-2xl border border-warn/40 bg-warn/10 px-3 py-2 text-xs text-warn/20">
           <AlertTriangle className="h-3.5 w-3.5" />
           <span>{rangeWarning}</span>
         </div>
       ) : null}
       {rangeHint ? (
-        <div className="flex items-center gap-2 rounded-2xl border border-white/10 bg-slate-900/60 px-3 py-2 text-xs text-zinc-300">
+        <div className="flex items-center gap-2 rounded-2xl border border-inverse/10 bg-card/60 px-3 py-2 text-xs text-muted-foreground">
           <Info className="h-3.5 w-3.5 text-accent" />
           <span>{rangeHint}</span>
         </div>
@@ -1450,31 +1560,68 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
       {viewMode === "combined"
         ? hasStudyActivity && domain && yDomain
           ? (
-              <TimelineChart
-                ref={svgRef}
-                series={series}
-                xDomain={domain}
-                yDomain={yDomain}
-                onViewportChange={(next, options) => handleViewportChange(next, { push: options?.push })}
-                height={variant === "compact" ? 320 : 460}
-                showGrid
-                fullDomain={fullDomain ?? undefined}
-                fullYDomain={fullYDomain ?? undefined}
-                examMarkers={showExamMarkers ? examMarkers : []}
-                timeZone={resolvedTimezone}
-                onResetDomain={handleResetDomain}
-                ariaDescribedBy={`timeline-zoom-shortcuts ${pointerInstructionId}`}
-                interactionMode={interactionMode}
-                temporaryPan={spacePanning}
-                onRequestStepBack={handleStepBack}
-                onTooSmallSelection={handleTooSmallSelection}
-                keyboardSelection={keyboardSelection}
-                showOpacityFade={showOpacityFade}
-                showReviewLines={showReviewMarkers}
-              />
+              <div className="space-y-3">
+                <TimelineChart
+                  ref={svgRef}
+                  series={series}
+                  xDomain={domain}
+                  yDomain={yDomain}
+                  onViewportChange={(next, options) => handleViewportChange(next, { push: options?.push })}
+                  height={variant === "compact" ? 320 : 460}
+                  showGrid
+                  fullDomain={fullDomain ?? undefined}
+                  fullYDomain={fullYDomain ?? undefined}
+                  examMarkers={showExamMarkers ? examMarkers : []}
+                  timeZone={resolvedTimezone}
+                  onResetDomain={handleResetDomain}
+                  ariaDescribedBy={`timeline-zoom-shortcuts ${pointerInstructionId}`}
+                  interactionMode={interactionMode}
+                  temporaryPan={spacePanning}
+                  onRequestStepBack={handleStepBack}
+                  onTooSmallSelection={handleTooSmallSelection}
+                  keyboardSelection={keyboardSelection}
+                  showOpacityGradient={showOpacityGradient}
+                  showReviewMarkers={showReviewMarkers}
+                  showEventDots={showEventDots}
+                  showTopicLabels={showTopicLabels}
+                />
+                {singleSubjectLegend ? (
+                  <div
+                    className="flex flex-wrap items-center gap-2 rounded-2xl border border-inverse/10 bg-card/60 px-3 py-2 text-xs text-muted-foreground"
+                    aria-label="Topic color legend"
+                  >
+                    <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                      Topic colors
+                    </span>
+                    {singleSubjectLegend.visible.map((topic) => {
+                      const color =
+                        singleSubjectColorOverrides?.get(topic.id) ?? resolveTopicColor(topic);
+                      return (
+                        <span
+                          key={topic.id}
+                          className="inline-flex items-center gap-2 rounded-full border border-inverse/10 bg-inverse/5 px-2 py-1"
+                        >
+                          <span
+                            className="inline-flex h-2 w-2 rounded-full"
+                            style={{ backgroundColor: color }}
+                          />
+                          <span className="max-w-[10rem] truncate text-[11px] text-fg/80">
+                            {topic.title}
+                          </span>
+                        </span>
+                      );
+                    })}
+                    {singleSubjectLegend.remaining > 0 ? (
+                      <span className="text-[11px] text-muted-foreground">
+                        +{singleSubjectLegend.remaining} more
+                      </span>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
             )
           : (
-              <div className="flex h-60 items-center justify-center rounded-3xl border border-dashed border-white/10 bg-slate-900/40 text-sm text-zinc-400">
+              <div className="flex h-60 items-center justify-center rounded-3xl border border-dashed border-inverse/10 bg-card/40 text-sm text-muted-foreground">
                 No study activity yet. Add a topic to see your timeline.
               </div>
             )
@@ -1494,7 +1641,7 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                   return (
                     <div
                       key={group.subjectId}
-                      className="space-y-2 rounded-3xl border border-white/10 bg-slate-900/50 p-4"
+                      className="space-y-2 rounded-3xl border border-inverse/10 bg-card/50 p-4"
                     >
                       <div className="flex items-center justify-between">
                         <div className="flex items-center gap-2">
@@ -1503,11 +1650,11 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                             style={{ backgroundColor: group.color }}
                             aria-hidden="true"
                           />
-                          <h3 className="text-sm font-semibold text-white">{group.label}</h3>
+                          <h3 className="text-sm font-semibold text-fg">{group.label}</h3>
                         </div>
                         <div className="flex items-center gap-2">
                           {examLabel ? (
-                            <span className="text-xs text-zinc-400">Exam {examLabel}</span>
+                            <span className="text-xs text-muted-foreground">Exam {examLabel}</span>
                           ) : null}
                           <Button
                             type="button"
@@ -1544,8 +1691,10 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                         onRequestStepBack={handleStepBack}
                         onTooSmallSelection={handleTooSmallSelection}
                         keyboardSelection={keyboardSelection}
-                        showOpacityFade={showOpacityFade}
-                        showReviewLines={showReviewMarkers}
+                        showOpacityGradient={showOpacityGradient}
+                        showReviewMarkers={showReviewMarkers}
+                        showEventDots={showEventDots}
+                        showTopicLabels={showTopicLabels}
                       />
                     </div>
                   );
@@ -1553,17 +1702,17 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
               </div>
             )
           : (
-              <div className="flex h-60 items-center justify-center rounded-3xl border border-dashed border-white/10 bg-slate-900/40 text-sm text-zinc-400">
+              <div className="flex h-60 items-center justify-center rounded-3xl border border-dashed border-inverse/10 bg-card/40 text-sm text-muted-foreground">
                 No study activity yet. Add a topic to see your timeline.
               </div>
             )}
 
       <div className="grid gap-4 md:grid-cols-2">
         <div className="space-y-2">
-          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             <Filter className="h-3.5 w-3.5" /> Visibility
           </div>
-          <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-400">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
             <Button size="sm" variant="ghost" onClick={showAllTopics}>
               Show all
             </Button>
@@ -1588,12 +1737,12 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
                     }))
                   }
                   className={`flex items-center gap-2 rounded-2xl border px-3 py-2 text-left text-xs transition ${
-                    isVisible ? "border-accent/40 bg-accent/10 text-white" : "border-white/10 bg-transparent text-zinc-400 hover:text-white"
+                    isVisible ? "border-accent/40 bg-accent/10 text-fg" : "border-inverse/10 bg-transparent text-muted-foreground hover:text-fg"
                   }`}
                 >
                   <span className="inline-flex h-2 w-2 rounded-full" style={{ backgroundColor: resolveTopicColor(topic) }} />
                   <span className="flex-1 truncate">{topic.title}</span>
-                  <span className="text-[10px] text-zinc-400">
+                  <span className="text-[10px] text-muted-foreground">
                     {formatDateWithWeekday(topic.nextReviewDate)}
                   </span>
                   {isVisible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
@@ -1603,13 +1752,13 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
           </div>
         </div>
 
-        <div className="space-y-3 rounded-2xl border border-white/5 bg-white/5 p-4">
-          <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-zinc-400">
+        <div className="space-y-3 rounded-2xl border border-inverse/5 bg-inverse/5 p-4">
+          <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             <span>Upcoming checkpoints</span>
             <span>{upcomingSchedule.length} topics</span>
           </div>
           {upcomingSchedule.length === 0 ? (
-            <p className="rounded-2xl border border-white/10 bg-slate-900/50 px-3 py-3 text-xs text-zinc-400">
+            <p className="rounded-2xl border border-inverse/10 bg-card/50 px-3 py-3 text-xs text-muted-foreground">
               As you add topics their next review dates will show up here.
             </p>
           ) : (
@@ -1617,19 +1766,19 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
               {upcomingSchedule.map((topic) => {
                 const due = isDueToday(topic.nextReviewDate);
                 return (
-                  <div key={topic.id} className="flex items-start gap-3 rounded-2xl border border-white/10 bg-slate-900/60 px-3 py-2">
+                  <div key={topic.id} className="flex items-start gap-3 rounded-2xl border border-inverse/10 bg-card/60 px-3 py-2">
                     <span
                       className="mt-1 inline-flex h-2 w-2 rounded-full"
-                      style={{ backgroundColor: due ? "#f97316" : resolveTopicColor(topic) }}
+                      style={{ backgroundColor: due ? "hsl(var(--warn))" : resolveTopicColor(topic) }}
                     />
                     <div className="flex-1">
-                      <p className="text-sm font-medium text-white">{topic.title}</p>
-                      <p className="text-xs text-zinc-400">
+                      <p className="text-sm font-medium text-fg">{topic.title}</p>
+                      <p className="text-xs text-muted-foreground">
                         {formatDateWithWeekday(topic.nextReviewDate)}  {formatRelativeToNow(topic.nextReviewDate)}
                       </p>
                     </div>
                     <span className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-[10px] font-semibold uppercase tracking-wide ${
-                      due ? "bg-rose-500/20 text-rose-100" : "bg-sky-500/15 text-sky-100"
+                      due ? "bg-error/20 text-error/20" : "bg-accent/15 text-accent/20"
                     }`}>
                       <Check className="h-3 w-3" /> {due ? "Due" : "Scheduled"}
                     </span>
@@ -1799,7 +1948,7 @@ function TimelineFullscreenDialog({
   const overlay = (
     <div
       ref={overlayRef}
-      className="fixed inset-0 z-[1200] flex flex-col bg-slate-950/95 backdrop-blur"
+      className="fixed inset-0 z-[1200] flex flex-col bg-bg/95 backdrop-blur"
       role="presentation"
       onMouseDown={(event) => {
         if (event.target === overlayRef.current) {
@@ -1814,14 +1963,14 @@ function TimelineFullscreenDialog({
         aria-labelledby={titleId}
         aria-describedby={descriptionId}
         tabIndex={-1}
-        className="flex h-full w-full flex-col gap-6 p-4 text-white sm:p-6"
+        className="flex h-full w-full flex-col gap-6 p-4 text-fg sm:p-6"
       >
         <header className="flex flex-wrap items-center justify-between gap-4">
           <div className="space-y-1">
-            <h2 id={titleId} className="text-xl font-semibold text-white">
+            <h2 id={titleId} className="text-xl font-semibold text-fg">
               {title}
             </h2>
-            <p id={descriptionId} className="text-sm text-zinc-300">
+            <p id={descriptionId} className="text-sm text-muted-foreground">
               {subtitle ?? "Interact with the expanded retention timeline."}
             </p>
           </div>
@@ -1836,10 +1985,10 @@ function TimelineFullscreenDialog({
           </Button>
         </header>
         <div className="flex min-h-0 flex-1 flex-col gap-4">
-          <div className="flex min-h-0 flex-1 items-stretch rounded-3xl border border-white/10 bg-slate-900/60 p-3">
+          <div className="flex min-h-0 flex-1 items-stretch rounded-3xl border border-inverse/10 bg-card/60 p-3">
             <div className="h-full w-full">{renderChart(chartHeight)}</div>
           </div>
-          <p className="text-xs text-zinc-400">
+          <p className="text-xs text-muted-foreground">
             Use the mouse wheel or touch gestures to zoom, drag to pan, or press Escape to exit fullscreen.
           </p>
         </div>

--- a/src/components/visualizations/timeline-panel.tsx
+++ b/src/components/visualizations/timeline-panel.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Toggle } from "@/components/ui/toggle";
+import { useTheme } from "next-themes";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { downloadSvg, downloadSvgAsPng } from "@/lib/export-svg";
 import { buildCurveSegments, sampleSegment } from "@/selectors/curves";
@@ -40,7 +41,9 @@ import {
   SquareDashedMousePointer,
   Maximize2,
   Minimize2,
-  Type
+  Type,
+  Moon,
+  Sun
 } from "lucide-react";
 import {
   daysBetween,
@@ -503,6 +506,8 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
       map.delete(subjectId);
     }
   }, []);
+  const { theme, resolvedTheme, setTheme } = useTheme();
+  const activeTheme = (theme ?? resolvedTheme ?? "light") as "light" | "dark";
 
   const domainMeta = React.useMemo(
     () => computeTimelineDomain(topics, subjects, resolvedTimezone),
@@ -1216,8 +1221,8 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
   };
 
   const cardClasses = variant === "compact"
-    ? "rounded-3xl border border-inverse/5 bg-card/50 p-5 shadow-lg shadow-slate-900/30"
-    : "rounded-3xl border border-inverse/5 bg-card/40 p-6 md:p-8 shadow-xl shadow-slate-900/30";
+    ? "rounded-3xl border border-inverse/5 bg-card/50 p-5"
+    : "rounded-3xl border border-inverse/5 bg-card/40 p-6 md:p-8";
 
   return (
     <>
@@ -1511,6 +1516,16 @@ export function TimelinePanel({ variant = "default", subjectFilter = null }: Tim
           >
             <Type className="h-3.5 w-3.5" />
             <span>Topic Labels</span>
+          </Toggle>
+          <Toggle
+            type="button"
+            pressed={activeTheme === "dark"}
+            onPressedChange={(pressed) => setTheme(pressed ? "dark" : "light")}
+            aria-label="Toggle theme"
+            title={activeTheme === "dark" ? "Switch to light theme" : "Switch to dark theme"}
+          >
+            {activeTheme === "dark" ? <Sun className="h-3.5 w-3.5" /> : <Moon className="h-3.5 w-3.5" />}
+            <span>Theme</span>
           </Toggle>
         </div>
         {categoryFilter.size > 0 ? (

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -1,4 +1,5 @@
 import { Subject, Topic } from "@/types/topic";
+import { FALLBACK_SUBJECT_COLOR } from "@/lib/colors";
 import {
   addMonthsInTimeZone,
   formatInTimeZone,
@@ -77,7 +78,7 @@ const deriveFallbackSubject = (subjects: Subject[]): SubjectInfo => {
     return {
       id: NO_SUBJECT_ID,
       name: "General",
-      color: "#38bdf8",
+      color: FALLBACK_SUBJECT_COLOR,
       icon: "Sparkles",
       examDate: null
     };

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -1,0 +1,168 @@
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const HSL_REGEX = /hsl\(\s*([\d.]+)\s*,\s*([\d.]+)%\s*,\s*([\d.]+)%\s*\)/i;
+
+export type HSLColor = { h: number; s: number; l: number };
+
+export const FALLBACK_SUBJECT_COLOR = "hsl(221, 83%, 53%)";
+
+const FALLBACK_HSL: HSLColor = { h: 221, s: 83, l: 53 };
+
+const normalizeHex = (hex: string): string | null => {
+  if (!hex) return null;
+  const value = hex.trim().replace(/^#/, "");
+  if (value.length === 3) {
+    return value
+      .split("")
+      .map((char) => char + char)
+      .join("")
+      .toLowerCase();
+  }
+  if (value.length === 6 && /^[0-9a-fA-F]{6}$/.test(value)) {
+    return value.toLowerCase();
+  }
+  return null;
+};
+
+const hexToHsl = (hex: string): HSLColor | null => {
+  const normalized = normalizeHex(hex);
+  if (!normalized) return null;
+  const r = parseInt(normalized.slice(0, 2), 16) / 255;
+  const g = parseInt(normalized.slice(2, 4), 16) / 255;
+  const b = parseInt(normalized.slice(4, 6), 16) / 255;
+
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const delta = max - min;
+
+  let hue = 0;
+  if (delta !== 0) {
+    if (max === r) {
+      hue = ((g - b) / delta) % 6;
+    } else if (max === g) {
+      hue = (b - r) / delta + 2;
+    } else {
+      hue = (r - g) / delta + 4;
+    }
+    hue *= 60;
+    if (hue < 0) hue += 360;
+  }
+
+  const lightness = (max + min) / 2;
+  const saturation = delta === 0 ? 0 : delta / (1 - Math.abs(2 * lightness - 1));
+
+  return {
+    h: hue,
+    s: saturation * 100,
+    l: lightness * 100
+  };
+};
+
+const parseHslString = (value: string): HSLColor | null => {
+  const match = value.match(HSL_REGEX);
+  if (!match) return null;
+  const h = Number.parseFloat(match[1]);
+  const s = Number.parseFloat(match[2]);
+  const l = Number.parseFloat(match[3]);
+  if (!Number.isFinite(h) || !Number.isFinite(s) || !Number.isFinite(l)) return null;
+  return {
+    h: ((h % 360) + 360) % 360,
+    s: clamp(s, 0, 100),
+    l: clamp(l, 0, 100)
+  };
+};
+
+const toHslString = ({ h, s, l }: HSLColor): string => {
+  const hue = Math.round(h * 10) / 10;
+  const saturation = Math.round(s * 10) / 10;
+  const lightness = Math.round(l * 10) / 10;
+  return `hsl(${hue}, ${saturation}%, ${lightness}%)`;
+};
+
+const parseToHsl = (color: string | null | undefined): HSLColor | null => {
+  if (!color) return null;
+  if (color.startsWith("#")) {
+    return hexToHsl(color);
+  }
+  if (color.trim().toLowerCase().startsWith("hsl")) {
+    return parseHslString(color);
+  }
+  return null;
+};
+
+const createAlternatingOffsets = (length: number, step: number): number[] => {
+  if (length <= 0) return [];
+  const offsets: number[] = [0];
+  let positive = step;
+  let negative = -step;
+  for (let index = 1; index < length; index += 1) {
+    if (index % 2 === 1) {
+      offsets.push(positive);
+      positive += step;
+    } else {
+      offsets.push(negative);
+      negative -= step;
+    }
+  }
+  return offsets;
+};
+
+export const generateTopicColorPalette = (baseColor: string, count: number): string[] => {
+  if (count <= 0) return [];
+  const base = parseToHsl(baseColor) ?? FALLBACK_HSL;
+  const sanitizedBase: HSLColor = {
+    h: base.h,
+    s: clamp(base.s, 60, 85),
+    l: clamp(base.l, 45, 60)
+  };
+
+  const hueStep = count > 1 ? Math.min(32, 120 / (count - 1)) : 0;
+  const hueOffsets = createAlternatingOffsets(count, hueStep);
+  const saturationOffsets = createAlternatingOffsets(count, 5);
+  const lightnessOffsets = createAlternatingOffsets(count, 4);
+
+  return hueOffsets.map((offset, index) => {
+    const hue = (sanitizedBase.h + offset + 360) % 360;
+    const saturation = clamp(sanitizedBase.s + saturationOffsets[index], 60, 90);
+    const lightness = clamp(sanitizedBase.l + lightnessOffsets[index], 40, 70);
+    return toHslString({ h: hue, s: saturation, l: lightness });
+  });
+};
+
+export const generateTopicColorMap = <T extends { id: string; title?: string }>(
+  baseColor: string,
+  topics: T[]
+): Map<string, string> => {
+  if (!topics || topics.length === 0) {
+    return new Map();
+  }
+  const sorted = [...topics].sort((a, b) => {
+    const titleA = ("title" in a && typeof a.title === "string") ? a.title : a.id;
+    const titleB = ("title" in b && typeof b.title === "string") ? b.title : b.id;
+    return titleA.localeCompare(titleB, undefined, { sensitivity: "base" });
+  });
+  const palette = generateTopicColorPalette(baseColor, sorted.length);
+  const map = new Map<string, string>();
+  sorted.forEach((topic, index) => {
+    map.set(topic.id, palette[index]);
+  });
+  return map;
+};
+
+type SoftenOptions = {
+  saturationScale?: number;
+  lightnessOffset?: number;
+};
+
+export const softenColorTone = (color: string, options: SoftenOptions = {}): string => {
+  const { saturationScale = 0.88, lightnessOffset = 4 } = options;
+  const hsl = parseToHsl(color);
+  if (!hsl) return color;
+  const softened: HSLColor = {
+    h: hsl.h,
+    s: clamp(hsl.s * saturationScale, 35, 95),
+    l: clamp(hsl.l + lightnessOffset, 30, 85)
+  };
+  return toHslString(softened);
+};
+

--- a/src/stores/profile.ts
+++ b/src/stores/profile.ts
@@ -2,6 +2,7 @@
 
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
+import { FALLBACK_SUBJECT_COLOR } from "@/lib/colors";
 
 export type Profile = {
   name: string;
@@ -25,7 +26,7 @@ const DEFAULT_PROFILE: Profile = {
   name: "Alex Rivera",
   email: "alex@example.com",
   role: "Learner",
-  avatarColor: "#38bdf8",
+  avatarColor: FALLBACK_SUBJECT_COLOR,
   timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "Asia/Colombo",
   notifications: {
     email: true,

--- a/src/stores/timeline-preferences.ts
+++ b/src/stores/timeline-preferences.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+type TimelinePreferencesState = {
+  showOpacityGradient: boolean;
+  showReviewMarkers: boolean;
+  showEventDots: boolean;
+  showTopicLabels: boolean;
+  setShowOpacityGradient: (value: boolean) => void;
+  setShowReviewMarkers: (value: boolean) => void;
+  setShowEventDots: (value: boolean) => void;
+  setShowTopicLabels: (value: boolean) => void;
+};
+
+export const useTimelinePreferencesStore = create<TimelinePreferencesState>()(
+  persist(
+    (set) => ({
+      showOpacityGradient: true,
+      showReviewMarkers: false,
+      showEventDots: true,
+      showTopicLabels: true,
+      setShowOpacityGradient: (value) => set({ showOpacityGradient: value }),
+      setShowReviewMarkers: (value) => set({ showReviewMarkers: value }),
+      setShowEventDots: (value) => set({ showEventDots: value }),
+      setShowTopicLabels: (value) => set({ showTopicLabels: value })
+    }),
+    {
+      name: "timeline-preferences",
+      version: 3,
+      migrate: (persistedState) => {
+        if (!persistedState || typeof persistedState !== "object") {
+          return persistedState as TimelinePreferencesState;
+        }
+
+        const state = persistedState as Partial<TimelinePreferencesState> & {
+          showOpacityFade?: boolean;
+        };
+
+        const showOpacityGradient =
+          typeof state.showOpacityGradient === "boolean"
+            ? state.showOpacityGradient
+            : typeof state.showOpacityFade === "boolean"
+              ? state.showOpacityFade
+              : true;
+
+        const showReviewMarkers =
+          typeof state.showReviewMarkers === "boolean" ? state.showReviewMarkers : false;
+
+        const showEventDots =
+          typeof state.showEventDots === "boolean" ? state.showEventDots : true;
+
+        const showTopicLabels =
+          typeof state.showTopicLabels === "boolean" ? state.showTopicLabels : true;
+
+        return {
+          showOpacityGradient,
+          showReviewMarkers,
+          showEventDots,
+          showTopicLabels
+        } as TimelinePreferencesState;
+      }
+    }
+  )
+);

--- a/src/stores/topics.ts
+++ b/src/stores/topics.ts
@@ -9,6 +9,7 @@ import {
   startOfDayInTimeZone
 } from "@/lib/date";
 import demoSeedData from "../data/demo-seed-data.json";
+import { FALLBACK_SUBJECT_COLOR } from "@/lib/colors";
 import {
   AutoAdjustPreference,
   ReviewKind,
@@ -137,7 +138,7 @@ const DEFAULT_GENERAL_EXAM_DATE = "2026-08-01T00:00:00.000Z";
 const createDefaultCategory = (): LegacyCategory => ({
   id: DEFAULT_SUBJECT_ID,
   label: "General Chemistry",
-  color: "#38bdf8",
+  color: FALLBACK_SUBJECT_COLOR,
   icon: "Sparkles"
 });
 
@@ -146,7 +147,7 @@ const createDefaultSubject = (): Subject => {
   return {
     id: DEFAULT_SUBJECT_ID,
     name: "General Chemistry",
-    color: "#38bdf8",
+    color: FALLBACK_SUBJECT_COLOR,
     icon: "Sparkles",
     examDate: DEFAULT_GENERAL_EXAM_DATE,
     difficultyModifier: 1,
@@ -829,7 +830,7 @@ const migrate = (persistedState: unknown, from: number): PersistedState => {
           subject = {
             id: subjectId ?? nanoid(),
             name: legacyLabel,
-            color: (topic as any).color ?? "#38bdf8",
+            color: (topic as any).color ?? FALLBACK_SUBJECT_COLOR,
             icon: (topic as any).icon ?? "Sparkles",
             examDate: (topic as any).examDate ?? null,
             createdAt: now,
@@ -903,7 +904,7 @@ export const useTopicStore = create<TopicStore>()(
         const subject: Subject = {
           id: nanoid(),
           name,
-          color: payload.color ?? "#38bdf8",
+          color: payload.color ?? FALLBACK_SUBJECT_COLOR,
           icon: payload.icon ?? "Sparkles",
           examDate: normalizeExamDate(payload.examDate),
           difficultyModifier: resolveDifficultyModifier(payload.difficultyModifier),
@@ -1087,7 +1088,7 @@ export const useTopicStore = create<TopicStore>()(
         }
 
         const subjectExamDate = resolvedSubject?.examDate ?? payload.examDate ?? null;
-        const subjectColor = resolvedSubject?.color ?? payload.color ?? "#38bdf8";
+        const subjectColor = resolvedSubject?.color ?? payload.color ?? FALLBACK_SUBJECT_COLOR;
         const subjectIcon = resolvedSubject?.icon ?? payload.icon ?? "Sparkles";
         const subjectDifficulty = resolveDifficultyModifier(resolvedSubject?.difficultyModifier);
         const startedOnIso = payload.startedOn ?? createdAt;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,14 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: light;
-}
-
-.dark {
-  color-scheme: dark;
-}
-
 body {
   @apply bg-bg text-fg font-sans antialiased;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,11 +3,15 @@
 @tailwind utilities;
 
 :root {
+  color-scheme: light;
+}
+
+.dark {
   color-scheme: dark;
 }
 
 body {
-  @apply bg-surface text-surface-foreground font-sans antialiased;
+  @apply bg-bg text-fg font-sans antialiased;
 }
 
 * {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,60 +1,67 @@
-/* Base tokens in HSL for Tailwind var() usage */
-:root {
-  /* surfaces */
+html {
+  color-scheme: light;
+
   --bg: 0 0% 100%;
-  --fg: 222 47% 11%;
-  --card: 0 0% 100%;
-  --card-foreground: 222 47% 11%;
+  --fg: 0 0% 10%;
+  --card: 210 20% 98%;
+  --card-foreground: 0 0% 10%;
   --muted: 210 16% 93%;
-  --muted-foreground: 215 16% 47%;
-  --border: 214 32% 91%;
-  --ring: 222 84% 56%;
+  --muted-foreground: 0 0% 40%;
+  --border: 0 0% 86%;
+  --ring: 215 100% 52%;
 
-  /* accents */
-  --accent: 221 83% 53%;
-  --accent-foreground: 210 40% 98%;
+  --accent: 215 100% 52%;
+  --accent-foreground: 0 0% 100%;
 
-  /* chart neutrals */
-  --grid: 220 14% 92%;
-  --axis: 215 16% 47%;
+  --grid: 210 16% 86%;
+  --axis: 0 0% 40%;
 
-  /* semantic statuses */
   --success: 142 71% 45%;
   --warn: 45 93% 47%;
   --error: 0 84% 60%;
 
-  /* overlays */
-  --overlay: 210 20% 96%;
-  --overlay-foreground: 222 47% 11%;
-  --inverse: 210 40% 98%;
-  --inverse-foreground: 222 47% 11%;
-  --shadow: 222 47% 15%;
+  --overlay: 0 0% 100%;
+  --overlay-foreground: 0 0% 10%;
+  --inverse: 210 25% 96%;
+  --inverse-foreground: 0 0% 25%;
+
+  --chart-line: 158 72% 47%;
+  --chart-fill-top: 158 72% 47%;
+  --chart-fill-bottom: 158 72% 47%;
 }
 
-/* Dark overrides */
-.dark {
-  --bg: 222 47% 6%;
-  --fg: 210 40% 98%;
-  --card: 222 47% 8%;
-  --card-foreground: 210 40% 98%;
-  --muted: 217 19% 27%;
-  --muted-foreground: 220 15% 70%;
-  --border: 217 19% 27%;
-  --ring: 221 83% 53%;
+html.light {
+  color-scheme: light;
+}
 
-  --accent: 221 83% 53%;
-  --accent-foreground: 210 40% 98%;
+html.dark {
+  color-scheme: dark;
 
-  --grid: 223 10% 20%;
-  --axis: 220 15% 65%;
+  --bg: 220 19% 7%;
+  --fg: 0 0% 96%;
+  --card: 220 16% 11%;
+  --card-foreground: 0 0% 96%;
+  --muted: 215 12% 24%;
+  --muted-foreground: 0 0% 70%;
+  --border: 215 12% 20%;
+  --ring: 152 69% 53%;
+
+  --accent: 152 69% 53%;
+  --accent-foreground: 0 0% 10%;
+
+  --grid: 220 14% 24%;
+  --axis: 0 0% 70%;
 
   --success: 142 71% 45%;
   --warn: 45 93% 47%;
   --error: 0 84% 60%;
 
-  --overlay: 217 33% 12%;
-  --overlay-foreground: 210 40% 98%;
-  --inverse: 210 40% 98%;
-  --inverse-foreground: 222 47% 6%;
-  --shadow: 222 47% 4%;
+  --overlay: 215 14% 12%;
+  --overlay-foreground: 0 0% 96%;
+  --inverse: 220 16% 18%;
+  --inverse-foreground: 0 0% 96%;
+
+  --chart-line: 152 80% 63%;
+  --chart-fill-top: 152 80% 63%;
+  --chart-fill-bottom: 152 80% 63%;
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,60 @@
+/* Base tokens in HSL for Tailwind var() usage */
+:root {
+  /* surfaces */
+  --bg: 0 0% 100%;
+  --fg: 222 47% 11%;
+  --card: 0 0% 100%;
+  --card-foreground: 222 47% 11%;
+  --muted: 210 16% 93%;
+  --muted-foreground: 215 16% 47%;
+  --border: 214 32% 91%;
+  --ring: 222 84% 56%;
+
+  /* accents */
+  --accent: 221 83% 53%;
+  --accent-foreground: 210 40% 98%;
+
+  /* chart neutrals */
+  --grid: 220 14% 92%;
+  --axis: 215 16% 47%;
+
+  /* semantic statuses */
+  --success: 142 71% 45%;
+  --warn: 45 93% 47%;
+  --error: 0 84% 60%;
+
+  /* overlays */
+  --overlay: 210 20% 96%;
+  --overlay-foreground: 222 47% 11%;
+  --inverse: 210 40% 98%;
+  --inverse-foreground: 222 47% 11%;
+  --shadow: 222 47% 15%;
+}
+
+/* Dark overrides */
+.dark {
+  --bg: 222 47% 6%;
+  --fg: 210 40% 98%;
+  --card: 222 47% 8%;
+  --card-foreground: 210 40% 98%;
+  --muted: 217 19% 27%;
+  --muted-foreground: 220 15% 70%;
+  --border: 217 19% 27%;
+  --ring: 221 83% 53%;
+
+  --accent: 221 83% 53%;
+  --accent-foreground: 210 40% 98%;
+
+  --grid: 223 10% 20%;
+  --axis: 220 15% 65%;
+
+  --success: 142 71% 45%;
+  --warn: 45 93% 47%;
+  --error: 0 84% 60%;
+
+  --overlay: 217 33% 12%;
+  --overlay-foreground: 210 40% 98%;
+  --inverse: 210 40% 98%;
+  --inverse-foreground: 222 47% 6%;
+  --shadow: 222 47% 4%;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,11 +29,6 @@ const config: Config = {
         success: "hsl(var(--success))",
         warn: "hsl(var(--warn))",
         error: "hsl(var(--error))",
-        slate: {
-          900: "hsl(var(--shadow))",
-          950: "hsl(var(--shadow))"
-        },
-        black: "hsl(var(--shadow))",
         overlay: "hsl(var(--overlay))",
         "overlay-foreground": "hsl(var(--overlay-foreground))",
         inverse: "hsl(var(--inverse))",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,10 +1,12 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: ["class"],
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./src/app/**/*.{js,ts,jsx,tsx,mdx}"
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/styles/**/*.{js,ts,jsx,tsx,mdx,css}"
   ],
   theme: {
     extend: {
@@ -12,20 +14,42 @@ const config: Config = {
         sans: ["Inter", "var(--font-inter)", "system-ui", "sans-serif"]
       },
       colors: {
-        surface: {
-          DEFAULT: "#0f172a",
-          foreground: "#f8fafc"
+        bg: "hsl(var(--bg))",
+        fg: "hsl(var(--fg))",
+        card: "hsl(var(--card))",
+        "card-foreground": "hsl(var(--card-foreground))",
+        muted: "hsl(var(--muted))",
+        "muted-foreground": "hsl(var(--muted-foreground))",
+        border: "hsl(var(--border))",
+        ring: "hsl(var(--ring))",
+        accent: "hsl(var(--accent))",
+        "accent-foreground": "hsl(var(--accent-foreground))",
+        grid: "hsl(var(--grid))",
+        axis: "hsl(var(--axis))",
+        success: "hsl(var(--success))",
+        warn: "hsl(var(--warn))",
+        error: "hsl(var(--error))",
+        slate: {
+          900: "hsl(var(--shadow))",
+          950: "hsl(var(--shadow))"
         },
-        accent: {
-          DEFAULT: "#38bdf8",
-          foreground: "#0f172a"
-        },
-        border: "#1f2937",
-        muted: "#1e293b",
-        card: {
-          DEFAULT: "#111827",
-          foreground: "#f8fafc"
-        }
+        black: "hsl(var(--shadow))",
+        overlay: "hsl(var(--overlay))",
+        "overlay-foreground": "hsl(var(--overlay-foreground))",
+        inverse: "hsl(var(--inverse))",
+        "inverse-foreground": "hsl(var(--inverse-foreground))"
+      },
+      borderColor: {
+        DEFAULT: "hsl(var(--border))"
+      },
+      textColor: {
+        DEFAULT: "hsl(var(--fg))"
+      },
+      backgroundColor: {
+        DEFAULT: "hsl(var(--bg))"
+      },
+      ringColor: {
+        DEFAULT: "hsl(var(--ring))"
       }
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,19 +28,22 @@
                                           "@/stores/*":  [
                                                              "./src/stores/*"
                                                          ],
-                                          "@/lib/*":  [
-                                                          "./src/lib/*"
-                                                      ],
-                                          "@/types/*":  [
-                                                            "./src/types/*"
-                                                        ],
-                                          "@/hooks/*":  [
-                                                            "./src/hooks/*"
-                                                        ],
-                                          "@/selectors/*":  [
-                                                                "./src/selectors/*"
-                                                            ]
-                                      },
+            "@/lib/*":  [
+                              "./src/lib/*"
+                          ],
+            "@/types/*":  [
+                              "./src/types/*"
+                          ],
+            "@/hooks/*":  [
+                              "./src/hooks/*"
+                          ],
+            "@/selectors/*":  [
+                                "./src/selectors/*"
+                            ],
+            "@/styles/*":  [
+                               "./src/styles/*"
+                           ]
+        },
                             "plugins":  [
                                             {
                                                 "name":  "next"


### PR DESCRIPTION
## Summary
- introduce tokenized light/dark color variables and wire Next Themes so layout loads the correct theme without flashes
- add a persistent theme toggle to the navigation bar and replace hard-coded color utilities across pages/components with token-based classes
- refresh timeline chart styling to pull axis, grid, and marker colors from the shared theme tokens for consistency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e1922d3a34833180f0fd187ef8b539