### PR TITLE
Refine timeline toolbar and focus flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+## [Unreleased]
+### Added
+- Adaptive review scheduler that recalculates next sessions whenever predicted retention drops below the user-defined trigger.
+- Global revision preference slider in Settings with real-time forgetting-curve preview and mode toggle.
+- Documentation for the retention model, adaptive UI, and validation strategy, including testing notes and algorithm overview.
+
+### Changed
+- Timeline, Subjects, and Reviews pages now surface the active retention trigger to explain upcoming adaptive sessions.
+- Topic creation aligns new cards with the global retention threshold automatically.
+
+### UI: Exam Date Badge Improvements
+- Fixed poor color contrast for exam-date badge on Reviews page.
+- Improved visibility under light/dark themes.
+- Standardized exam badge color palette (amber tones).
+- Added hover/focus transitions and accessibility attributes.
+
+### Dashboard UI & Chart Refinements
+- Default the dashboard status filter to "Due today" and persist the preference across sessions.
+- Unify the filter button group with uppercase primary styling, horizontal scroll, and accessible focus rings.
+- Introduced a hoverable review-load chart with lighter grid lines, accent gradients, and responsive tooltips.
+- Tidied the search, filters, and chart layout so controls remain on a single row and the clear-filters action uses muted inline text.
+
+### Dashboard Layout Update
+- Repositioned the “Progress today” module directly beneath the daily summary cards so completion status appears before filters.
+- Added soft divider rules above and below the progress module to separate major dashboard sections.
+- Balanced spacing and headings to match surrounding sections in both light and dark themes.
+
+### Reviews Page Enhancements
+- Fixed the runtime error triggered by the "All" filter by guarding invalid status lookups.
+- Limited the “Skip today” shortcut to topics due today while keeping other actions available.
+- Retired the review-load preview chart to focus on actionable rows.
+- Rebuilt the reviews table with a responsive, GitHub-inspired layout, hoverable rows, and inline expansion for schedule and notes.
+
+### Dark Mode Contrast Improvements
+- Brightened core dark-mode text tokens to keep secondary copy legible against slate backgrounds.
+- Raised muted and placeholder greys for improved hierarchy without sacrificing comfort.
+- Updated status hues so overdue, upcoming, and exam accents clear WCAG contrast targets.
+- Confirmed readability across dashboard summaries, tables, and subject cards in low-light themes.
+
+### Timeline UI Refinement
+- Simplified the timeline toolbar into compact icon toggles, merging checkpoints and review markers into a shared milestones control and removing redundant theme/label switches.
+- Limited the view to a single active subject with focus chips, subject badges, and scrollable filters so other subjects stay hidden until reselected.
+- Added hover-aware chart styling with crosshair cursors, curve isolation on click, and lighter grid treatments for clearer comparisons.
+- Hardened SVG/PNG exports with sanitized clones, cross-origin safeguards, and user-facing fallbacks when filters taint the canvas.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ Thanks for your interest in helping improve the Spaced Repetition App! This docu
 - Write TypeScript using strict typing and prefer existing utility helpers where available.
 - Keep components small and composable; colocate unit tests alongside the code they cover.
 - Follow Tailwind conventions already established in the codebase and use design tokens defined in `tailwind.config.ts`.
+- When introducing filter rails or status chips, match the dashboard pattern: active buttons use `bg-primary/10 text-primary border-primary` with `focus-visible:ring-primary/50`, inactive buttons stay muted until `hover:bg-accent/20` elevates them, and the group remains a single-line, scrollable flex row.
 
 ## Documentation
 

--- a/DESIGN_NOTES.md
+++ b/DESIGN_NOTES.md
@@ -1,0 +1,8 @@
+# Design Notes
+
+## Dashboard layout rationale
+
+- **Progress visibility** – Moving the Progress today module directly beneath the daily summary cards keeps completion feedback front-and-centre so learners see motivation cues before filtering topics.
+- **Section separators** – Introducing subtle divider rules above and below the progress card creates distinct modules without heavy shadows, making the dashboard easier to scan in light and dark themes.
+- **Typography alignment** – Matching the Progress today heading scale with other section titles preserves rhythm across the page and reinforces the hierarchy of supporting body text.
+- **Accent usage** – Highlighting completion percentages and motivation copy with the success palette ties the card back to other positive states (e.g., streak and completion chips) while maintaining required contrast.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ The Spaced Repetition App is a local-first study companion built with Next.js, T
 - [Security notes](docs/security.md)
 - [OpenAPI stewardship](docs/openapi.yaml)
 - [UI style audit](docs/ui-style-audit.md)
+- [Adaptive algorithm overview](docs/ALGORITHM_OVERVIEW.md)
+- [Settings guide](SETTINGS_GUIDE.md)
+- [UI guidelines](UI_GUIDELINES.md)
+- [Testing notes](TESTING_NOTES.md)
+- [Changelog](CHANGELOG.md)
 - [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Contributing guide](CONTRIBUTING.md)
 - [Security policy](SECURITY.md)
@@ -18,17 +23,26 @@ The Spaced Repetition App is a local-first study companion built with Next.js, T
 
 ## What changed recently
 
+- Launched adaptive review scheduling driven by the forgetting curve, including a configurable retention trigger and live preview in Settings.
 - Introduced a light/dark theme toggle with hard-coded palettes so every surface, icon, and label reads consistently without relying on CSS variables.
 - Flattened the UI aesthetic—cards, dialogs, and inputs now use crisp borders instead of shadows while charts retain their soft gradients.
-- Polished the timeline with per-topic labels at the Today line, review-to-review connector segments, and opacity-aware fade controls.
+- Polished the timeline with icon-based overlays, single-subject focus chips, and hoverable curves that isolate when clicked.
 - Hardened light mode contrast so nav links, review statuses, and exam countdowns stay readable on bright surfaces.
 - Added flat per-subject revision tables and hoverable review badges beneath the timeline for a spreadsheet-style snapshot of progress.
 - Simplified the dashboard to focus on today’s review plan, filters, and streak metrics while keeping the full analytics experience on the Timeline page.
 
+### UI Enhancements
+
+- Exam date badges now adapt dynamically to theme mode and maintain color accessibility standards across pages.
+- The dashboard opens with the "Due today" status chip selected, scrollable primary filters, and a hover-aware review load chart that previews upcoming topics at a glance.
+- The “Progress today” module now sits above the filters with matching dividers, so you can check completion status before browsing topics.
+- The Reviews page now uses a GitHub-inspired table with responsive columns, expandable details, and skip actions limited to due-today topics.
+- Dark mode text contrast has been brightened so secondary labels, notes, and placeholders stay legible on deep slate backgrounds.
+
 ## Key concepts
 
 - **Subject** – The canonical home for icon, colour, and optional exam date. Editing a subject updates every topic, calendar dot, and timeline marker instantly.
-- **Topic** – A single study card with notes, reminder preferences, and spaced intervals. Topics inherit identity from their subject and can be reviewed once per local day.
+- **Topic** – A single study card with notes, reminder preferences, and an adaptive review cadence. Topics inherit identity from their subject, can be reviewed once per local day, and automatically reschedule when predicted retention falls past your chosen trigger.
 - **Review** – A logged study event that advances the interval schedule. Early reviews honour the learner’s auto-adjust preference.
 - **Calendar dots** – One dot per subject per day in the calendar view, tinted by subject colour with overflow summarised as `+N`.
 - **Timeline markers** – Dotted vertical exam indicators in the subject’s colour, visible in exports and toggleable from the toolbar.
@@ -58,7 +72,7 @@ The Spaced Repetition App is a local-first study companion built with Next.js, T
 
 ## Themes
 
-- Toggle between the light and dark palettes from the header controls or the timeline toolbar—both modes use fixed colour values so surfaces stay visually consistent offline.
+- Toggle between the light and dark palettes from the header controls; both modes use fixed colour values so surfaces stay visually consistent offline.
 - Theme selection persists via local storage, so the app restores your preference on reload and across navigation.
 - The flat design keeps focus outlines and chart gradients readable in both modes without relying on box shadows.
 

--- a/SETTINGS_GUIDE.md
+++ b/SETTINGS_GUIDE.md
@@ -1,0 +1,10 @@
+# Settings Guide
+
+## Revision strategy
+
+- **Mode toggle** – Choose between **Adaptive** (default) and **Fixed interval**. Adaptive mode applies the forgetting-curve scheduler globally. Fixed mode preserves the static interval lists you may have configured manually.
+- **Retention trigger slider** – Available in adaptive mode. Range: 30–80%. The slider controls the retention percentage that will trigger the next review for every topic. Adjustments reschedule upcoming reviews immediately using the forgetting-curve model.
+- **Live preview** – The right-hand panel charts the predicted decay from the last review to the trigger point and lists the next few checkpoints. Use it to validate how far the scheduler will push upcoming sessions.
+- **Projected cadence list** – Displays the next four review dates computed for a sample topic. Dates respect subject exam caps.
+
+Tip: lower triggers (~30–40%) favour more frequent refreshers; higher triggers (~70–80%) lengthen spacing to prioritise long-term retention.

--- a/TESTING_NOTES.md
+++ b/TESTING_NOTES.md
@@ -1,0 +1,40 @@
+# Testing Notes
+
+## Adaptive scheduler coverage
+
+- **Unit tests** – Extend `tests/forgetting-curve.test.ts` to cover interval generation across multiple triggers (30%, 50%, 70%). Ensure that higher triggers result in shorter intervals and that the floor is respected.
+- **Scheduler projection** – Add tests for `projectAdaptiveSchedule` verifying that review dates stop at the exam boundary and that stability growth applies α/β adjustments.
+- **Integration checks** – After changing the trigger slider, confirm that:
+  - Topics immediately update their `nextReviewDate` and `retrievabilityTarget` values in the store.
+  - Timeline, Subjects, and Reviews pages reflect the new trigger string in their headers.
+  - The Settings preview chart re-renders with the new trigger line.
+- **Manual QA** – Toggle between Adaptive and Fixed modes to verify that slider enablement and explanatory states behave as expected.
+- **Regression suite** – Run `npm run lint` and `npm run test:curve` to ensure code quality and mathematical helpers remain stable.
+
+## Exam badge contrast
+
+- **Theme coverage** – Verify the badge copy and icon remain legible on both light and dark backgrounds.
+- **Interaction states** – Confirm hover and keyboard focus states transition the background tint without harming contrast.
+- **Cross-page parity** – Ensure the same badge styling renders on `/subjects` and `/reviews` without divergence.
+
+## Reviews table interactions
+
+- **Filter stability** – Click through All, Overdue, Due today, and Upcoming to ensure no runtime errors occur and the badge copy updates accordingly.
+- **Skip action guard** – Confirm the “Skip today” button renders only for rows whose status is `due-today`; upcoming topics should not expose the control.
+- **Expansion details** – Toggle a row open and verify that schedule metadata (intervals, last reviewed, exam countdown) and notes render within the detail panel.
+- **Responsive layout** – Resize the viewport to mobile widths to confirm the table scrolls horizontally, the condensed metadata appears under the topic title, and action buttons remain usable.
+
+## Dark mode contrast
+
+- **Global scan** – Enable dark mode and review dashboard summaries, subject cards, and reviews tables to ensure secondary copy (`text-muted-foreground`) stays legible.
+- **Placeholder sweep** – Focus each major search/input field to confirm placeholder text resolves to the brighter slate tone instead of fading out.
+- **Status chips** – Inspect overdue, upcoming, and exam badges on dark backgrounds for ≥4.5:1 contrast between text and pill fill.
+- **Assistive text** – Check captions, tooltips, and muted helper text for readable hierarchy without dipping below AA contrast ratios.
+
+## Timeline toolbar and chart
+
+- **Icon toggles** – Click each toolbar toggle (exam markers, milestones, event dots, opacity fade, topic labels) to confirm ON/OFF states persist and the icons remain on a single scrollable row.
+- **Milestones linkage** – Turning off the milestones control should hide both checkpoint dots and review stitches; turning it back on should restore both.
+- **Subject chips** – Select different subject chips and verify only one chart renders at a time, the selected chip highlights, and the badge above the chart updates to match the subject colour.
+- **Curve isolation** – Hover and click individual curves to ensure stroke widths grow, other series dim, and clicking empty space restores all curves.
+- **Export fallback** – With filters applied, run SVG/PNG exports to ensure the PNG helper either downloads successfully or surfaces the “Export failed…” toast instead of crashing.

--- a/THEME_TOKENS.md
+++ b/THEME_TOKENS.md
@@ -1,0 +1,18 @@
+# Theme Tokens
+
+## Exam status palette
+
+- **warn-light-bg** – `#FEF3C7` (Tailwind `bg-amber-100`).
+- **warn-light-text** – `#92400E` (Tailwind `text-amber-700`).
+- **warn-dark-bg** – `rgba(146, 64, 14, 0.4)` (Tailwind `dark:bg-amber-900/40`).
+- **warn-dark-text** – `#FCD34D` (Tailwind `dark:text-amber-300`).
+- **warn-border-light** – `#FCD34D` (Tailwind `border-amber-300`).
+- **warn-border-dark** – `rgba(180, 83, 9, 0.6)` (Tailwind `dark:border-amber-700/60`).
+
+## Dark mode text palette
+
+- **primary** – `#EAEAEA` (applied via `text-fg`).
+- **secondary** – `#D4D4D8` (applied via `text-muted-foreground`).
+- **muted** – `rgba(212, 212, 216, 0.8)` (applied via `text-muted-foreground/80`).
+- **placeholder** – `#9CA3AF` (set through the dark-mode `::placeholder` rule and disabled text).
+- **status hues** – Overdue `#F87171`, Upcoming `#60A5FA`, Exam `#FBBF24` to maintain contrast against `#0F1115`.

--- a/UI_GUIDELINES.md
+++ b/UI_GUIDELINES.md
@@ -1,0 +1,62 @@
+# UI Guidelines
+
+## Adaptive Review Preview UI
+
+- **Slider styling** – Use the native range input with `accent-accent` to stay on-brand. Label and helper text should remain in the muted foreground palette for readability.
+- **Mode pill buttons** – Display the Adaptive/Fixed toggle as a rounded pill group. Highlight the active mode with the accent background and inverse text.
+- **Preview card** – Render the forgetting curve as an SVG line inside a rounded card. Include a dashed horizontal line for the trigger threshold and annotate the next checkpoint with an accent dot.
+- **Cadence list** – Limit to four projected reviews to avoid scroll overflow. Each entry should use compact chips with the review index on the left and formatted date on the right.
+- **Empty states** – When fixed mode is active or no adaptive checkpoints exist before the exam, show a dashed card explaining the state instead of an empty chart.
+
+## Dark Mode Text Hierarchy
+
+- **Primary copy** – Default body text and headings should use `text-fg` which resolves to `#eaeaea` in dark mode.
+- **Secondary copy** – Supporting paragraphs, metadata rows, and helper labels should apply `text-muted-foreground` (`#d4d4d8`) so they remain readable without overpowering headlines.
+- **Muted details** – Captions, microcopy, and icon hints can drop to `text-muted-foreground/80` (`rgba(212, 212, 216, 0.8)`) to establish hierarchy while retaining ≥4.5:1 contrast.
+- **Placeholders & disabled** – Inputs and controls should use `::placeholder { color: #9ca3af; }` and disabled text around `#9ca3af` to avoid disappearing on the `#0f1115` background.
+- **Status accents** – Overdue, upcoming, and exam indicators must keep the bright rose/sky/amber palettes so alert colours are still distinguishable against dark surfaces.
+
+## Exam Date Badge Design
+
+- **Light mode** – Use `bg-amber-100`, `text-amber-700`, and `border-amber-300` for the badge container and copy.
+- **Dark mode** – Switch to `bg-amber-900/40`, `text-amber-300`, and `border-amber-700/60` to retain contrast on dark surfaces.
+- **Hover** – Transition to `bg-amber-200` in light mode and `bg-amber-800/60` in dark mode while keeping border colors intact.
+- **Icon color** – Icons must set `stroke="currentColor"` (default for Lucide) so the glyph matches the surrounding text tone.
+- **Accessibility** – Maintain at least a 4.5:1 contrast ratio between foreground and background in every theme.
+
+## Dashboard Filters & Chart Interactions
+
+- **Status filter rail** – Wrap the chip group in `flex gap-2 whitespace-nowrap overflow-x-auto scrollbar-none scroll-smooth snap-x snap-mandatory` so the buttons stay on a single line and scroll on small screens.
+- **Active state** – Apply `bg-primary/10 text-primary border-primary font-semibold hover:bg-primary/15 focus-visible:ring-primary/50` to the selected status chip.
+- **Inactive state** – Use `border-transparent text-muted-foreground hover:bg-accent/20 hover:text-fg` while keeping uppercase labels and `tracking-wide` letter spacing.
+- **Clear filters control** – Render as muted inline text (`text-xs text-muted-foreground hover:underline`) aligned to the right, without a pill or border.
+- **Review load chart** – Place the preview inside a `bg-muted/30` container with `cursor-crosshair`; draw the area with an accent gradient, keep grid lines at 60% opacity, and bump stroke width plus drop-shadow on hover.
+- **Tooltip motion** – Fade tooltips in/out with `transition-opacity duration-150` and keep copy within the card palette so it remains legible in both themes.
+- **Accessibility** – Ensure the active chip and tooltip text both exceed a 4.5:1 contrast ratio against their backgrounds and the chart summary announces the due-now count via `sr-only` text.
+
+## Dashboard Section Order
+
+- **Sequence** – Arrange the dashboard as: header + hero copy, daily metric cards, Next Up messaging, streak/due summary, Progress today, then the search, filters, and topic table.
+- **Dividers** – Place `border-t border-border/60` dividers immediately above and below the Progress today card to separate it from adjacent content without introducing heavy shadows.
+- **Spacing** – Maintain roughly `gap-10` between primary blocks and `space-y-6` within the divider stack so the layout breathes on both mobile and desktop breakpoints.
+- **Typography** – Reuse the standard section heading scale (`text-2xl font-semibold`) for the Progress today title, while keeping supporting copy in the muted foreground palette.
+- **Positive accents** – Style completion percentages and motivational copy with `text-success` (or equivalent positive tone) to reinforce achievement across themes.
+
+## Timeline Toolbar Rules
+
+- **Icon toggles** – Render timeline overlays (exam markers, milestones, event dots, opacity fade, topic labels) as icon-only `Toggle` controls sized `h-9 w-9`, centred, and wrapped in a scrollable chip rail.
+- **Milestones combo** – Merge checkpoints and review markers into a single “Milestones” control that flips both `showCheckpoints` and `showReviewMarkers` together.
+- **Subject focus** – Show only one subject’s data at a time. Below the chart, expose subject chips that behave as mutually exclusive toggles and default to the first available subject.
+- **Curve isolation** – Clicking a curve should dim other series, apply a drop-shadow highlight, and re-show everything when the background is clicked or Escape is pressed. Hover states use thicker strokes and pointer cursors.
+- **Clear filters text** – The clear-categories action is plain text (`text-xs text-muted-foreground hover:underline`) aligned to the right of the toolbar.
+- **Export guardrails** – PNG exports must sanitise cloned SVGs, set `image.crossOrigin = "anonymous"`, and toast an error (“Export failed…”) when the browser blocks `toDataURL`.
+- **Hover affordances** – Charts live inside `rounded-3xl border border-inverse/10 bg-muted/30` containers so grid lines and curves brighten slightly on hover while keeping crosshair cursors.
+
+## Reviews Table Design
+
+- **Column order** – Topic, Subject, Next review, Status, Actions. Keep headers uppercase, `text-xs`, and left-aligned except for the Actions column, which should align right.
+- **Row behaviour** – Apply `cursor-pointer hover:bg-muted/30` to each `<tr>` so the entire row signals interactivity. Toggle expansion with Enter/Space when the row has focus and rotate the chevron indicator accordingly.
+- **Expanded details** – Render the schedule and notes summary inside a single detail row spanning all columns (`colSpan={5}`) with a muted background and 12–16px padding.
+- **Skip logic** – Only show the “Skip today” action for topics whose status is `due-today`. Upcoming topics should expose edit/delete without a skip affordance.
+- **Visual language** – Use flat borders (`border-border/50`), light neutral backgrounds, and compact `px-4 py-3` cell padding to mimic GitHub tables. Status badges reuse the shared `status-chip` palette.
+- **Responsive handling** – Wrap the table in `overflow-x-auto` for small screens and surface condensed metadata (subject, next review, status) beneath the topic title with `md:hidden` helpers.

--- a/docs/ALGORITHM_OVERVIEW.md
+++ b/docs/ALGORITHM_OVERVIEW.md
@@ -1,0 +1,70 @@
+# Adaptive Revision Scheduler Overview
+
+The adaptive scheduler is anchored to the exponential forgetting curve:
+
+\[ R(t) = \exp\left(-\frac{t}{s}\right) \]
+
+- **R(t)** – predicted retention at elapsed time *t* (days).
+- **s** – topic stability measured in days.
+
+## Trigger-driven intervals
+
+Learners choose a retention trigger **T** (30–80%). The next review interval is derived directly from the curve:
+
+\[ t_{\text{next}} = -s \cdot \ln(T) \]
+
+This interval represents the point where retention is expected to decay to the trigger level. Every rescheduled review resets retention to ~100% and uses the same trigger to compute the next checkpoint.
+
+## Stability growth and lapses
+
+We gradually lengthen future reviews using two tunable parameters:
+
+- **α (alpha)** = 0.25 by default. After a successful review the scheduler multiplies stability by *(1 + α)*.
+- **β (beta)** = 0.15 by default. Each missed review applies a penalty of *(1 – β)*.
+
+The parameters mirror the richer `updateStability` model used when real reviews are logged, but keep the preview predictable.
+
+## Projection loop
+
+Pseudocode for generating the schedule used in previews and documentation:
+
+```
+next = []
+stability = clamp(stability, min, max)
+count = currentReviews
+anchor = lastReviewDate
+while next.length < limit and beforeExam(anchor):
+    interval = computeIntervalDays(stability, trigger)
+    anchor = anchor + interval
+    retention = computeRetrievability(stability, interval)
+    next.push({ interval, anchor, retention })
+    stability *= 1 + alpha
+    apply lapse penalties if requested
+```
+
+Each projected checkpoint records:
+
+- sequential index
+- scheduled ISO date
+- interval in days
+- retention immediately before the review
+
+The live app truncates the list once the exam date would be exceeded.
+
+## Example
+
+For a new topic (*s* = 1 day) and trigger **T = 0.5**:
+
+| Review | Stability (days) | Interval (days) | Scheduled when retention ≈ | Date offset |
+| ------ | ---------------- | --------------- | -------------------------- | ----------- |
+| 1      | 1.00             | 0.69            | 50%                         | +0.69 days  |
+| 2      | 1.25             | 0.86            | 50%                         | +1.55 days  |
+| 3      | 1.56             | 1.08            | 50%                         | +2.63 days  |
+
+After each review the stability grows by 25%, pushing later sessions further into the future.
+
+## Relationship to production scheduling
+
+- The **preview** uses the simplified α/β growth factors described above for clarity.
+- Actual review events in the app still rely on the richer `updateStability` heuristics that factor in spacing, streaks, and quality.
+- Both systems converge on the same core rule: schedule the next review the moment retention is predicted to hit the configured trigger.

--- a/src/app/reviews/page.tsx
+++ b/src/app/reviews/page.tsx
@@ -1,70 +1,143 @@
-﻿"use client";
+"use client";
 
 import * as React from "react";
 import { useRouter } from "next/navigation";
 import { useTopicStore } from "@/stores/topics";
 import { useProfileStore } from "@/stores/profile";
-import { TopicCard } from "@/components/dashboard/topic-card";
-import { Button } from "@/components/ui/button";
-import { Clock } from "lucide-react";
-import { formatRelativeToNow, nowInTimeZone } from "@/lib/date";
+import { useReviewPreferencesStore } from "@/stores/review-preferences";
+import {
+  TopicList,
+  TopicListItem,
+  TopicStatus,
+  StatusFilter,
+  SubjectFilterValue
+} from "@/components/dashboard/topic-list";
+import { useZonedNow } from "@/hooks/use-zoned-now";
+import { computeRiskScore, getAverageQuality } from "@/lib/forgetting-curve";
+import { startOfToday } from "@/lib/date";
+import type { Subject } from "@/types/topic";
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+const STATUS_STORAGE_KEY = "reviews-status-filter";
 
 export default function ReviewsPage() {
   const router = useRouter();
-  const topics = useTopicStore((state) => state.topics);
+  const { topics, subjects } = useTopicStore((state) => ({
+    topics: state.topics,
+    subjects: state.subjects
+  }));
   const timezone = useProfileStore((state) => state.profile.timezone) || "Asia/Colombo";
-  const [now, setNow] = React.useState(() => nowInTimeZone(timezone));
+  const reviewTrigger = useReviewPreferencesStore((state) => state.reviewTrigger);
+  const triggerPercent = Math.round(reviewTrigger * 100);
+  const zonedNow = useZonedNow(timezone);
+
+  const [statusFilter, setStatusFilter] = React.useState<StatusFilter>("due-today");
+  const [subjectFilter, setSubjectFilter] = React.useState<SubjectFilterValue>(null);
 
   React.useEffect(() => {
-    const interval = window.setInterval(() => {
-      setNow(nowInTimeZone(timezone));
-    }, 60_000);
-    return () => window.clearInterval(interval);
-  }, [timezone]);
+    if (typeof window === "undefined") return;
+    const stored = window.sessionStorage.getItem(STATUS_STORAGE_KEY);
+    if (!stored) return;
+    if (stored === "all" || stored === "overdue" || stored === "due-today" || stored === "upcoming") {
+      setStatusFilter(stored);
+    }
+  }, []);
 
-  const dueTopics = React.useMemo(() => {
-    const reference = now.getTime();
-    return topics
-      .filter((topic) => new Date(topic.nextReviewDate).getTime() <= reference)
-      .sort((a, b) => new Date(a.nextReviewDate).getTime() - new Date(b.nextReviewDate).getTime());
-  }, [now, topics]);
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.sessionStorage.setItem(STATUS_STORAGE_KEY, statusFilter);
+  }, [statusFilter]);
+
+  const enrichedTopics = React.useMemo<TopicListItem[]>(() => {
+    const subjectMap = new Map<string, Subject>();
+    for (const subject of subjects) {
+      subjectMap.set(subject.id, subject);
+    }
+
+    const start = startOfToday().getTime();
+    const endOfTodayMs = start + DAY_IN_MS;
+
+    return topics.map((topic) => {
+      const nextTime = new Date(topic.nextReviewDate).getTime();
+      let status: TopicStatus;
+      if (!Number.isFinite(nextTime) || Number.isNaN(nextTime)) {
+        status = "upcoming";
+      } else if (nextTime < start) {
+        status = "overdue";
+      } else if (nextTime < endOfTodayMs) {
+        status = "due-today";
+      } else {
+        status = "upcoming";
+      }
+
+      const subject = topic.subjectId ? subjectMap.get(topic.subjectId) ?? null : null;
+
+      return {
+        topic,
+        subject,
+        status,
+        risk: computeRiskScore({
+          now: zonedNow,
+          stabilityDays: topic.stability,
+          targetRetrievability: topic.retrievabilityTarget,
+          lastReviewedAt: topic.lastReviewedAt,
+          nextReviewAt: topic.nextReviewDate,
+          reviewsCount: topic.reviewsCount,
+          averageQuality: getAverageQuality(
+            (topic.events ?? [])
+              .filter((event) => event.type === "reviewed" && typeof event.reviewQuality === "number")
+              .map((event) => event.reviewQuality as number)
+          ),
+          examDate: subject?.examDate ?? null,
+          difficultyModifier: subject?.difficultyModifier ?? topic.subjectDifficultyModifier ?? 1
+        })
+      } satisfies TopicListItem;
+    });
+  }, [topics, subjects, zonedNow]);
+
+  const actionableCount = React.useMemo(
+    () => enrichedTopics.filter((item) => item.status !== "upcoming").length,
+    [enrichedTopics]
+  );
+
+  const handleEditTopic = React.useCallback(
+    (id: string) => {
+      router.push(`/topics/${id}/edit`);
+    },
+    [router]
+  );
+
+  const handleCreateTopic = React.useCallback(() => {
+    router.push("/topics/new");
+  }, [router]);
 
   return (
-    <section className="space-y-6">
-      <header className="flex flex-col gap-2">
-        <h1 className="reviews-header text-3xl font-semibold">Today’s Reviews</h1>
-        <p className="reviews-subtext text-sm">
-          Focus on the topics that are due right now. Knock them out to keep your streak alive.
+    <section className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold">Reviews</h1>
+        <p className="text-sm text-muted-foreground">
+          Stay on pace by tackling the topics that are due now. We’ll cue up new reviews when your predicted retention dips below
+          {" "}
+          {triggerPercent}%.
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {actionableCount} topic{actionableCount === 1 ? "" : "s"} currently need attention.
         </p>
       </header>
 
-      {dueTopics.length === 0 ? (
-        <div className="rounded-3xl border border-inverse/5 bg-inverse/5 p-8 text-center text-sm text-muted-foreground">
-          <Clock className="mx-auto mb-3 h-8 w-8 text-accent" />
-          You’re all caught up for today. Great work!
-          <div className="mt-4 flex justify-center">
-            <Button variant="outline" onClick={() => router.push("/timeline")}>
-              View schedule
-            </Button>
-          </div>
-        </div>
-      ) : (
-        <div className="space-y-4">
-          <div className="flex items-center justify-between rounded-2xl border border-inverse/10 bg-inverse/5 px-4 py-3 text-sm text-muted-foreground">
-            <span className="reviews-summary font-medium">{dueTopics.length} topic{dueTopics.length === 1 ? "" : "s"} waiting</span>
-            <span className="review-date text-xs">Next up {formatRelativeToNow(dueTopics[0]!.nextReviewDate)}</span>
-          </div>
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {dueTopics.map((topic) => (
-              <TopicCard
-                key={topic.id}
-                topic={topic}
-                onEdit={() => router.push(`/topics/${topic.id}/edit`)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
+      <TopicList
+        id="reviews-topic-list"
+        items={enrichedTopics}
+        subjects={subjects}
+        timezone={timezone}
+        zonedNow={zonedNow}
+        onEditTopic={handleEditTopic}
+        onCreateTopic={handleCreateTopic}
+        statusFilter={statusFilter}
+        onStatusFilterChange={setStatusFilter}
+        subjectFilter={subjectFilter}
+        onSubjectFilterChange={setSubjectFilter}
+      />
     </section>
   );
 }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -2,17 +2,33 @@
 
 import * as React from "react";
 import { useProfileStore } from "@/stores/profile";
+import { useReviewPreferencesStore } from "@/stores/review-preferences";
+import { useTopicStore } from "@/stores/topics";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { ColorPicker } from "@/components/forms/color-picker";
 import { BellRing, SwitchCamera } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { projectAdaptiveSchedule } from "@/lib/adaptive-scheduler";
+import {
+  DAY_MS,
+  DEFAULT_RETENTION_FLOOR,
+  DEFAULT_STABILITY_DAYS,
+  STABILITY_MIN_DAYS,
+  computeRetrievability
+} from "@/lib/forgetting-curve";
+import { formatDateWithWeekday, formatRelativeToNow } from "@/lib/date";
 
 export default function SettingsPage() {
   const profile = useProfileStore((state) => state.profile);
   const updateProfile = useProfileStore((state) => state.updateProfile);
   const toggleNotification = useProfileStore((state) => state.toggleNotification);
+  const reviewTrigger = useReviewPreferencesStore((state) => state.reviewTrigger);
+  const mode = useReviewPreferencesStore((state) => state.mode);
+  const setMode = useReviewPreferencesStore((state) => state.setMode);
+  const setReviewTrigger = useReviewPreferencesStore((state) => state.setReviewTrigger);
+  const triggerPercent = Math.round(reviewTrigger * 100);
 
   const [form, setForm] = React.useState(profile);
 
@@ -134,6 +150,223 @@ export default function SettingsPage() {
           <Button type="submit">Save profile</Button>
         </div>
       </form>
+
+      <div className="space-y-6 rounded-3xl border border-inverse/5 bg-card/60 p-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-fg">Revision strategy</h2>
+            <p className="text-sm text-muted-foreground">
+              Tune the adaptive forgetting-curve model or fall back to manual fixed intervals.
+            </p>
+          </div>
+          <div className="inline-flex overflow-hidden rounded-full border border-inverse/10 bg-inverse/5 text-xs font-semibold uppercase tracking-wide">
+            <button
+              type="button"
+              onClick={() => setMode("adaptive")}
+              className={cn(
+                "px-3 py-2 transition",
+                mode === "adaptive"
+                  ? "bg-accent text-accent-foreground"
+                  : "text-muted-foreground hover:text-fg"
+              )}
+            >
+              Adaptive
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("fixed")}
+              className={cn(
+                "px-3 py-2 transition",
+                mode === "fixed" ? "bg-muted text-fg" : "text-muted-foreground hover:text-fg"
+              )}
+            >
+              Fixed interval
+            </button>
+          </div>
+        </div>
+
+        <p className="text-xs text-muted-foreground">
+          {mode === "fixed"
+            ? "Manual intervals stay in place. Adaptive scheduling is paused until you switch modes."
+            : "The app will reschedule every topic as soon as its predicted retention reaches your trigger threshold."}
+        </p>
+
+        <div className="space-y-3 rounded-2xl border border-inverse/10 bg-inverse/5 p-4">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="review-trigger" className="text-sm font-medium text-fg">
+              Revise when retention ≤ {triggerPercent}%
+            </Label>
+            <span className="text-xs text-muted-foreground">{triggerPercent}%</span>
+          </div>
+          <input
+            id="review-trigger"
+            type="range"
+            min={30}
+            max={80}
+            step={1}
+            value={triggerPercent}
+            disabled={mode === "fixed"}
+            onChange={(event) => setReviewTrigger(Number(event.target.value) / 100)}
+            className="w-full accent-accent"
+            aria-describedby="review-trigger-helper"
+          />
+          <div className="flex justify-between text-[10px] uppercase tracking-widest text-muted-foreground/70">
+            <span>30%</span>
+            <span id="review-trigger-helper">Adaptive range</span>
+            <span>80%</span>
+          </div>
+        </div>
+
+        <AdaptiveStrategyPreview disabled={mode === "fixed"} />
+      </div>
     </section>
   );
 }
+
+type AdaptiveStrategyPreviewProps = {
+  disabled: boolean;
+};
+
+const AdaptiveStrategyPreview: React.FC<AdaptiveStrategyPreviewProps> = ({ disabled }) => {
+  const reviewTrigger = useReviewPreferencesStore((state) => state.reviewTrigger);
+  const alpha = useReviewPreferencesStore((state) => state.alpha);
+  const beta = useReviewPreferencesStore((state) => state.beta);
+  const topics = useTopicStore((state) => state.topics);
+  const subjects = useTopicStore((state) => state.subjects);
+
+  const baseline = React.useMemo(() => {
+    if (disabled) return null;
+    if (topics.length === 0) {
+      const now = new Date();
+      return {
+        stability: DEFAULT_STABILITY_DAYS,
+        reviewsCount: 0,
+        anchorDate: now,
+        examDate: null as Date | null,
+        topicTitle: null as string | null
+      };
+    }
+    const sorted = [...topics].sort((a, b) => {
+      const aTime = new Date(a.lastReviewedAt ?? a.startedAt ?? a.createdAt).getTime();
+      const bTime = new Date(b.lastReviewedAt ?? b.startedAt ?? b.createdAt).getTime();
+      return bTime - aTime;
+    });
+    const sample = sorted[0]!;
+    const anchorIso = sample.lastReviewedAt ?? sample.startedAt ?? sample.createdAt;
+    const anchorDate = new Date(anchorIso);
+    const subject = sample.subjectId
+      ? subjects.find((entry) => entry.id === sample.subjectId) ?? null
+      : null;
+    return {
+      stability: Number.isFinite(sample.stability) ? sample.stability : DEFAULT_STABILITY_DAYS,
+      reviewsCount: sample.reviewsCount ?? 0,
+      anchorDate: Number.isFinite(anchorDate.getTime()) ? anchorDate : new Date(),
+      examDate: subject?.examDate ? new Date(subject.examDate) : null,
+      topicTitle: sample.title
+    };
+  }, [disabled, topics, subjects]);
+
+  if (disabled) {
+    return (
+      <div className="rounded-2xl border border-dashed border-inverse/10 bg-inverse/5 p-4 text-sm text-muted-foreground">
+        Fixed interval mode keeps using the per-topic interval lists. Switch back to adaptive mode to project retention-based
+        checkpoints.
+      </div>
+    );
+  }
+
+  if (!baseline) {
+    return null;
+  }
+
+  const schedule = projectAdaptiveSchedule({
+    anchorDate: baseline.anchorDate,
+    stabilityDays: baseline.stability,
+    reviewsCount: baseline.reviewsCount,
+    reviewTrigger,
+    examDate: baseline.examDate,
+    alpha,
+    beta,
+    maxReviews: 5
+  });
+
+  const nextReview = schedule[0] ?? null;
+  const horizonDays = Math.max(nextReview?.intervalDays ?? 1, 0.5);
+  const stability = Math.max(baseline.stability, STABILITY_MIN_DAYS);
+  const width = 320;
+  const height = 160;
+  const horizonMs = horizonDays * DAY_MS;
+
+  const steps = 48;
+  const segments: string[] = [];
+  for (let index = 0; index <= steps; index += 1) {
+    const ratio = index / steps;
+    const elapsedMs = ratio * horizonMs;
+    const retention = computeRetrievability(stability, elapsedMs, DEFAULT_RETENTION_FLOOR);
+    const x = ratio * width;
+    const y = height - retention * height;
+    segments.push(`${index === 0 ? "M" : "L"}${x.toFixed(2)} ${y.toFixed(2)}`);
+  }
+  const path = segments.join(" ");
+
+  const triggerY = height - reviewTrigger * height;
+  const markerX = width;
+  const examLabel = baseline.examDate ? formatDateWithWeekday(baseline.examDate.toISOString()) : null;
+  const nextRelative = nextReview ? formatRelativeToNow(nextReview.date) : null;
+
+  return (
+    <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(0,240px)]">
+      <div className="rounded-2xl border border-inverse/10 bg-inverse/5 p-4">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
+          <span>{baseline.topicTitle ?? "Sample topic"}</span>
+          {examLabel ? <span>Exam {examLabel}</span> : null}
+        </div>
+        <svg viewBox={`0 0 ${width} ${height}`} className="mt-3 h-40 w-full" aria-hidden="true">
+          <rect x={0} y={0} width={width} height={height} rx={12} className="fill-transparent" />
+          <path d={path} className="fill-none stroke-accent" strokeWidth={2} />
+          <line x1={0} y1={triggerY} x2={width} y2={triggerY} strokeWidth={1} strokeDasharray="4 4" className="stroke-muted-foreground/40" />
+          <circle cx={markerX} cy={triggerY} r={4} className="fill-accent" />
+        </svg>
+        <p className="mt-2 text-xs text-muted-foreground">
+          Curve shows predicted retention from the last review to the next trigger checkpoint.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3 text-sm">
+        {nextReview ? (
+          <div className="rounded-xl border border-inverse/10 bg-inverse/5 p-3">
+            <p className="font-semibold text-fg">Next review {formatDateWithWeekday(nextReview.date)}</p>
+            <p className="text-xs text-muted-foreground">
+              {Math.round(nextReview.intervalDays)} days out • {nextRelative ?? "soon"}
+            </p>
+          </div>
+        ) : (
+          <div className="rounded-xl border border-dashed border-inverse/10 bg-inverse/5 p-3 text-xs text-muted-foreground">
+            No adaptive reviews within the exam window.
+          </div>
+        )}
+
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Projected cadence</p>
+          {schedule.length > 0 ? (
+            <ul className="space-y-1 text-xs text-muted-foreground">
+              {schedule.slice(0, 4).map((checkpoint) => (
+                <li
+                  key={checkpoint.index}
+                  className="flex items-center justify-between rounded-lg border border-inverse/10 bg-inverse/5 px-3 py-2"
+                >
+                  <span>Review {checkpoint.index}</span>
+                  <span>{formatDateWithWeekday(checkpoint.date)}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="rounded-lg border border-dashed border-inverse/10 bg-inverse/5 px-3 py-2 text-xs text-muted-foreground">
+              Exam window is too close to schedule another adaptive review.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -1,15 +1,23 @@
-﻿"use client";
+"use client";
 
 import * as React from "react";
+
 import { TimelinePanel } from "@/components/visualizations/timeline-panel";
+import { useReviewPreferencesStore } from "@/stores/review-preferences";
 
 export default function TimelinePage() {
+  const reviewTrigger = useReviewPreferencesStore((state) => state.reviewTrigger);
+  const triggerPercent = Math.round(reviewTrigger * 100);
+
   return (
     <section className="space-y-6">
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold text-fg">Timeline</h1>
         <p className="text-sm text-muted-foreground">
           Visualise upcoming reviews alongside retention curves to plan your study sessions with confidence.
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Adaptive scheduler will ping each topic when retention reaches approximately {triggerPercent}%.
         </p>
       </header>
 

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -55,7 +55,7 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
   const resolvedTimezone = timezone || "Asia/Colombo";
   const zonedNow = useZonedNow(resolvedTimezone);
 
-  const [statusFilter, setStatusFilter] = React.useState<StatusFilter>("all");
+  const [statusFilter, setStatusFilter] = React.useState<StatusFilter>("due-today");
   const { subjectFilter, setSubjectFilter } = usePersistedSubjectFilter();
 
   useIsomorphicLayoutEffect(() => {
@@ -227,13 +227,23 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
   }, []);
 
   return (
-    <section className="flex flex-col gap-8 lg:gap-10">
+    <section className="flex flex-col gap-10">
       <DailySummarySection
         dueCount={filteredDueCount}
         upcomingCount={filteredUpcomingCount}
         streak={streak}
         nextTopic={filteredNextTopic}
       />
+
+      <div className="space-y-6">
+        <SectionDivider />
+        <ProgressTodayModule
+          completed={completedCount}
+          total={totalToday}
+          completionPercent={completionPercent}
+        />
+        <SectionDivider />
+      </div>
 
       <TopicList
         id="dashboard-topic-list"
@@ -248,8 +258,6 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
         subjectFilter={resolvedSubjectFilter}
         onSubjectFilterChange={handleSubjectFilterChange}
       />
-
-      <ProgressTodayModule completed={completedCount} total={totalToday} completionPercent={completionPercent} />
     </section>
   );
 };
@@ -263,33 +271,42 @@ const ProgressTodayModule = ({
   total: number;
   completionPercent: number;
 }) => {
-  const safeTotal = total === 0 ? completed : total;
-  const safePercent = Number.isFinite(completionPercent) ? Math.max(0, Math.min(100, completionPercent)) : 0;
-  const isComplete = safePercent >= 100;
-  const summaryText = `${completed}/${safeTotal} reviews completed • ${safePercent}% complete. Keep up the rhythm — every checkmark keeps your memory sharp.`;
+  const plannedTotal = total;
+  const displayPercent = Number.isFinite(completionPercent)
+    ? Math.max(0, Math.min(100, completionPercent))
+    : 0;
+  const isComplete = displayPercent >= 100;
+  const hasScheduledReviews = plannedTotal > 0;
+  const ratioHeading = hasScheduledReviews
+    ? `${completed}/${plannedTotal} reviews completed`
+    : `${completed} reviews completed`;
+  const summaryText = hasScheduledReviews
+    ? `You’ve completed ${completed} of ${plannedTotal} scheduled reviews for today.`
+    : "No reviews are scheduled today. Add a topic to keep the rhythm going.";
+  const encouragement = hasScheduledReviews
+    ? isComplete
+      ? "Great work! You're on track for your streak."
+      : "Keep going to finish today’s queue and boost your streak."
+    : "Plan your next review to keep the momentum strong.";
 
   return (
     <section className="progress-summary rounded-3xl border border-inverse/10 bg-card/60 px-6 py-8 md:px-8">
       <div className="space-y-5">
         <div className="space-y-2">
           <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Progress today</p>
-          <h2 className="text-3xl font-semibold text-fg">
-            {completed}/{safeTotal} reviews completed
-          </h2>
+          <h2 className="text-2xl font-semibold text-fg">{ratioHeading}</h2>
           <p className="text-sm text-muted-foreground">{summaryText}</p>
         </div>
         <div className="space-y-1">
-          <p className="text-sm font-semibold text-fg">{safePercent}% complete</p>
-          <p className="text-sm text-muted-foreground">
-            {isComplete
-              ? "Great work! You\u2019ve completed today\u2019s reviews."
-              : "Finish today to extend your streak."}
-          </p>
+          <p className="text-base font-semibold text-success">{displayPercent}% complete</p>
+          <p className="text-sm font-medium text-success">{encouragement}</p>
         </div>
       </div>
     </section>
   );
 };
+
+const SectionDivider = () => <div role="separator" className="border-t border-border/60" />;
 
 const DailySummarySection = ({
   dueCount,

--- a/src/components/dashboard/topic-card.tsx
+++ b/src/components/dashboard/topic-card.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { IconPreview } from "@/components/icon-preview";
 import { Button } from "@/components/ui/button";
+import { StatusBadge } from "@/components/ui/status-badge";
 import { QuickRevisionDialog } from "@/components/dashboard/quick-revision-dialog";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
@@ -453,9 +454,12 @@ export const TopicCard: React.FC<TopicCardProps> = ({ topic, onEdit }) => {
                   </span>
                 ) : null}
                 {examDateLabel ? (
-                  <span className="exam-date inline-flex items-center gap-2 rounded-full bg-warn/15 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide">
-                    <CalendarClock className="h-3.5 w-3.5" /> Exam {examDateLabel}
-                  </span>
+                  <StatusBadge
+                    type="exam"
+                    className="exam-date"
+                    label={`Exam ${examDateLabel}`}
+                    date={subject?.examDate ?? undefined}
+                  />
                 ) : null}
               </div>
             </div>

--- a/src/components/dashboard/topic-list.tsx
+++ b/src/components/dashboard/topic-list.tsx
@@ -7,7 +7,6 @@ import { Input } from "@/components/ui/input";
 import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
 import { QuickRevisionDialog } from "@/components/dashboard/quick-revision-dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { IconPreview } from "@/components/icon-preview";
 import { useTopicStore } from "@/stores/topics";
 import { Subject, Topic } from "@/types/topic";
 import type { RiskScore } from "@/lib/forgetting-curve";
@@ -17,6 +16,7 @@ import {
   Check,
   CheckCircle2,
   ChevronDown,
+  ChevronRight,
   Ellipsis,
   Flame,
   Pencil,
@@ -237,7 +237,7 @@ export function TopicList({
   }, [clearSearch]);
 
   const handleResetFilters = React.useCallback(() => {
-    onStatusFilterChange("all");
+    onStatusFilterChange("due-today");
     onSubjectFilterChange(null);
     setSubjectOpen(false);
   }, [onStatusFilterChange, onSubjectFilterChange]);
@@ -294,8 +294,11 @@ export function TopicList({
 
   const filterDescriptions = React.useMemo(() => {
     const descriptions: string[] = [];
-    if (statusFilter !== "all") {
-      descriptions.push(`Status ${STATUS_META[statusFilter].label}`);
+    if (statusFilter !== "due-today") {
+      const statusMeta = statusFilter === "all" ? null : STATUS_META[statusFilter];
+      if (statusMeta) {
+        descriptions.push(`Status ${statusMeta.label}`);
+      }
     }
     if (subjectFilter !== null) {
       if (subjectFilter.size === 0) {
@@ -391,8 +394,8 @@ export function TopicList({
       className="rounded-[32px] border border-inverse/5 bg-card/50 p-5 backdrop-blur xl:p-8"
     >
       <div className="flex flex-col gap-5 xl:gap-6">
-        <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:gap-8">
-          <div role="search" className="w-full xl:flex-1 xl:min-w-0">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div role="search" className="w-full lg:max-w-2xl lg:flex-1 lg:min-w-0">
             <label htmlFor="dashboard-topic-search" className="sr-only">
               Search topics
             </label>
@@ -472,170 +475,170 @@ export function TopicList({
               </p>
             </div>
           </div>
-          <div className="flex flex-col gap-3 xl:flex-1">
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <Button
-                type="button"
-                onClick={onCreateTopic}
-                className="inline-flex items-center gap-2 rounded-full bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
-              >
-                <Sparkles className="h-4 w-4" aria-hidden="true" /> Add topic
-              </Button>
+          <div className="flex flex-none items-start justify-end">
+            <Button
+              type="button"
+              onClick={onCreateTopic}
+              className="inline-flex items-center gap-2 rounded-full bg-accent px-4 py-2 text-sm font-semibold text-accent-foreground transition hover:bg-accent/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+            >
+              <Sparkles className="h-4 w-4" aria-hidden="true" /> Add topic
+            </Button>
+          </div>
+        </div>
 
-              <div className="flex flex-1 flex-wrap items-center gap-2 text-xs text-muted-foreground xl:flex-nowrap xl:justify-end xl:gap-3">
-                <div
-                  className="flex items-center gap-1 rounded-full border border-inverse/10 bg-card/60 p-1"
-                  role="group"
-                  aria-label="Filter by status"
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+            <div
+              className="flex min-w-0 gap-2 overflow-x-auto whitespace-nowrap scrollbar-none scroll-smooth snap-x snap-mandatory"
+              role="group"
+              aria-label="Filter by status"
+            >
+              {statusFilters.map(({ value, label }) => (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => onStatusFilterChange(value)}
+                  aria-pressed={statusFilter === value}
+                  className={cn(
+                    "flex-shrink-0 snap-start rounded-md border px-3 py-1.5 text-sm font-medium uppercase tracking-wide transition-all duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+                    statusFilter === value
+                      ? "border-primary bg-primary/10 text-primary font-semibold hover:bg-primary/15"
+                      : "border-transparent text-muted-foreground hover:bg-accent/20 hover:text-fg"
+                  )}
                 >
-                  {statusFilters.map(({ value, label }) => (
-                    <Button
-                      key={value}
-                      type="button"
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => onStatusFilterChange(value)}
-                      aria-pressed={statusFilter === value}
-                      className={cn(
-                        "rounded-full px-3 py-1 text-xs transition",
-                        statusFilter === value
-                          ? "bg-accent text-accent-foreground hover:bg-accent/90"
-                          : "text-muted-foreground hover:text-fg"
-                      )}
-                    >
-                      {label}
-                    </Button>
-                  ))}
-                </div>
+                  {label}
+                </button>
+              ))}
+            </div>
 
-                <Popover open={subjectOpen} onOpenChange={setSubjectOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="inline-flex items-center gap-2 rounded-full border-inverse/15 bg-card/60 px-3 py-1 text-xs text-fg/80 hover:border-inverse/25 hover:text-fg"
-                    >
-                      <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
-                      {subjectsLabel}
-                      <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-72 rounded-2xl border border-inverse/10 bg-card/95 p-3 text-sm text-fg">
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Subjects</span>
-                      <div className="flex items-center gap-2">
-                        <button
-                          type="button"
-                          className="text-xs font-medium text-accent hover:underline"
-                          onClick={() => {
-                            onSubjectFilterChange(null);
-                            setSubjectOpen(false);
-                          }}
-                        >
-                          Select all
-                        </button>
-                        <button
-                          type="button"
-                          className="text-xs font-medium text-muted-foreground hover:underline"
-                          onClick={() => onSubjectFilterChange(new Set<string>())}
-                        >
-                          Clear all
-                        </button>
-                      </div>
+            <div className="flex flex-none items-center gap-2 whitespace-nowrap">
+              <Popover open={subjectOpen} onOpenChange={setSubjectOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="inline-flex items-center gap-2 rounded-full border-inverse/15 bg-card/60 px-3 py-1 text-xs text-fg/80 hover:border-inverse/25 hover:text-fg"
+                  >
+                    <Sparkles className="h-3.5 w-3.5" aria-hidden="true" />
+                    {subjectsLabel}
+                    <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-72 rounded-2xl border border-inverse/10 bg-card/95 p-3 text-sm text-fg">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Subjects</span>
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        className="text-xs font-medium text-accent hover:underline"
+                        onClick={() => {
+                          onSubjectFilterChange(null);
+                          setSubjectOpen(false);
+                        }}
+                      >
+                        Select all
+                      </button>
+                      <button
+                        type="button"
+                        className="text-xs font-medium text-muted-foreground hover:underline"
+                        onClick={() => onSubjectFilterChange(new Set<string>())}
+                      >
+                        Clear all
+                      </button>
                     </div>
-                    <div className="mt-3">
-                      <label htmlFor="subject-filter-search" className="sr-only">
-                        Search subjects
-                      </label>
-                      <div className="relative">
-                        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/80" aria-hidden="true" />
-                        <Input
-                          id="subject-filter-search"
-                          type="search"
-                          value={subjectSearch}
-                          onChange={(event) => setSubjectSearch(event.target.value)}
-                          placeholder="Search subjects"
-                          className="h-9 w-full rounded-xl border-inverse/10 bg-bg/80 pl-9 pr-3 text-xs text-fg placeholder:text-muted-foreground/80 focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent/40"
-                        />
-                      </div>
+                  </div>
+                  <div className="mt-3">
+                    <label htmlFor="subject-filter-search" className="sr-only">
+                      Search subjects
+                    </label>
+                    <div className="relative">
+                      <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground/80" aria-hidden="true" />
+                      <Input
+                        id="subject-filter-search"
+                        type="search"
+                        value={subjectSearch}
+                        onChange={(event) => setSubjectSearch(event.target.value)}
+                        placeholder="Search subjects"
+                        className="h-9 w-full rounded-xl border-inverse/10 bg-bg/80 pl-9 pr-3 text-xs text-fg placeholder:text-muted-foreground/80 focus-visible:border-accent focus-visible:ring-2 focus-visible:ring-accent/40"
+                      />
                     </div>
-                    <div className="mt-3 max-h-64 space-y-1 overflow-y-auto">
-                      {subjectOptions.length === 0 ? (
-                        <p className="text-xs text-muted-foreground">No subjects yet.</p>
-                      ) : filteredSubjectOptions.length === 0 ? (
-                        <p className="text-xs text-muted-foreground">No matching subjects.</p>
-                      ) : (
-                        filteredSubjectOptions.map((option) => {
-                          const isChecked = subjectFilter === null ? true : subjectFilter.has(option.id);
-                          return (
-                            <button
-                              key={option.id}
-                              type="button"
-                              onClick={() => toggleSubject(option.id)}
-                              role="menuitemcheckbox"
-                              aria-checked={isChecked}
-                              className="flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm transition hover:bg-inverse/10"
-                            >
-                              <span className="flex items-center gap-2">
-                                <span className="flex h-2.5 w-2.5 rounded-full" style={{ backgroundColor: option.color }} />
-                                {option.name}
+                  </div>
+                  <div className="mt-3 max-h-64 space-y-1 overflow-y-auto">
+                    {subjectOptions.length === 0 ? (
+                      <p className="text-xs text-muted-foreground">No subjects yet.</p>
+                    ) : filteredSubjectOptions.length === 0 ? (
+                      <p className="text-xs text-muted-foreground">No matching subjects.</p>
+                    ) : (
+                      filteredSubjectOptions.map((option) => {
+                        const isChecked = subjectFilter === null ? true : subjectFilter.has(option.id);
+                        return (
+                          <button
+                            key={option.id}
+                            type="button"
+                            onClick={() => toggleSubject(option.id)}
+                            role="menuitemcheckbox"
+                            aria-checked={isChecked}
+                            className="flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left text-sm transition hover:bg-inverse/10"
+                          >
+                            <span className="flex items-center gap-2">
+                              <span className="flex h-2.5 w-2.5 rounded-full" style={{ backgroundColor: option.color }} />
+                              {option.name}
+                            </span>
+                            <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                              {option.count}
+                              <span
+                                className={cn(
+                                  "flex h-5 w-5 items-center justify-center rounded-full border",
+                                  isChecked
+                                    ? "border-accent bg-accent/20 text-accent"
+                                    : "border-inverse/20 text-muted-foreground/80"
+                                )}
+                              >
+                                {isChecked ? <Check className="h-3 w-3" aria-hidden="true" /> : null}
                               </span>
-                              <span className="flex items-center gap-2 text-xs text-muted-foreground">
-                                {option.count}
-                                <span
-                                  className={cn(
-                                    "flex h-5 w-5 items-center justify-center rounded-full border",
-                                    isChecked
-                                      ? "border-accent bg-accent/20 text-accent"
-                                      : "border-inverse/20 text-muted-foreground/80"
-                                  )}
-                                >
-                                  {isChecked ? <Check className="h-3 w-3" aria-hidden="true" /> : null}
-                                </span>
-                              </span>
-                            </button>
-                          );
-                        })
-                      )}
-                    </div>
-                  </PopoverContent>
-                </Popover>
+                            </span>
+                          </button>
+                        );
+                      })
+                    )}
+                  </div>
+                </PopoverContent>
+              </Popover>
 
-                <Popover open={sortOpen} onOpenChange={setSortOpen}>
-                  <PopoverTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="inline-flex items-center gap-2 rounded-full border-inverse/15 bg-card/60 px-3 py-1 text-xs text-fg/80 hover:border-inverse/25 hover:text-fg"
-                    >
-                      <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" /> Sort by: {sortLabels[sortOption]}
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-56 rounded-2xl border border-inverse/10 bg-card/95 p-2 text-sm text-fg">
-                    <div className="space-y-1">
-                      {(Object.keys(sortLabels) as SortOption[]).map((value) => (
-                        <button
-                          key={value}
-                          type="button"
-                          onClick={() => {
-                            setSortOption(value);
-                            setSortOpen(false);
-                          }}
-                          className={cn(
-                            "flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left transition",
-                            sortOption === value ? "bg-accent/20 text-fg" : "hover:bg-inverse/10 hover:text-fg"
-                          )}
-                        >
-                          <span>{sortLabels[value]}</span>
-                          {sortOption === value ? <CheckCircle2 className="h-3.5 w-3.5 text-accent" aria-hidden="true" /> : null}
-                        </button>
-                      ))}
-                    </div>
-                  </PopoverContent>
-                </Popover>
-              </div>
+              <Popover open={sortOpen} onOpenChange={setSortOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="inline-flex items-center gap-2 rounded-full border-inverse/15 bg-card/60 px-3 py-1 text-xs text-fg/80 hover:border-inverse/25 hover:text-fg"
+                  >
+                    <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" /> Sort by: {sortLabels[sortOption]}
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-56 rounded-2xl border border-inverse/10 bg-card/95 p-2 text-sm text-fg">
+                  <div className="space-y-1">
+                    {(Object.keys(sortLabels) as SortOption[]).map((value) => (
+                      <button
+                        key={value}
+                        type="button"
+                        onClick={() => {
+                          setSortOption(value);
+                          setSortOpen(false);
+                        }}
+                        className={cn(
+                          "flex w-full items-center justify-between gap-3 rounded-xl px-3 py-2 text-left transition",
+                          sortOption === value ? "bg-accent/20 text-fg" : "hover:bg-inverse/10 hover:text-fg"
+                        )}
+                      >
+                        <span>{sortLabels[value]}</span>
+                        {sortOption === value ? <CheckCircle2 className="h-3.5 w-3.5 text-accent" aria-hidden="true" /> : null}
+                      </button>
+                    ))}
+                  </div>
+                </PopoverContent>
+              </Popover>
             </div>
           </div>
         </div>
@@ -645,11 +648,11 @@ export function TopicList({
             Showing {totalFilteredCount} of {items.length} topics
             {totalHiddenCount > 0 ? ` • ${totalHiddenCount} hidden by filters` : ""}
           </span>
-          {(searchInput || statusFilter !== "all" || subjectFilter !== null) && totalHiddenCount > 0 ? (
+          {searchInput || statusFilter !== "due-today" || subjectFilter !== null ? (
             <button
               type="button"
               onClick={handleResetFilters}
-              className="rounded-full border border-inverse/10 px-3 py-1 text-[11px] uppercase tracking-wide text-muted-foreground transition hover:border-inverse/30 hover:text-fg"
+              className="ml-auto text-xs font-medium text-muted-foreground transition hover:text-fg hover:underline"
             >
               Clear filters
             </button>
@@ -689,7 +692,7 @@ export function TopicList({
                   type="button"
                   variant="outline"
                   onClick={handleResetFilters}
-                  disabled={statusFilter === "all" && (subjectFilter === null || subjectFilter.size === totalSubjectOptions)}
+                  disabled={statusFilter === "due-today" && (subjectFilter === null || subjectFilter.size === totalSubjectOptions)}
                   className="rounded-full border-inverse/20 bg-transparent px-4 py-2 text-sm text-fg transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:opacity-40"
                 >
                   Reset filters
@@ -697,26 +700,42 @@ export function TopicList({
               </div>
             </div>
           ) : (
-            <div className="overflow-hidden rounded-3xl border border-inverse/5 bg-bg/40">
-              <div className="hidden border-b border-inverse/5 px-6 py-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground md:grid md:grid-cols-[minmax(0,2.5fr)_minmax(0,1.2fr)_minmax(0,1.3fr)_minmax(0,1fr)_auto]">
-                <span>Topic</span>
-                <span>Subject</span>
-                <span>Next review</span>
-                <span>Status</span>
-                <span className="text-right">Actions</span>
-              </div>
-              <div className="divide-y divide-border/40">
-                {filteredItems.map((row) => (
-                  <TopicListRow
-                    key={row.topic.id}
-                    item={row}
-                    subject={row.subject ?? subjectLookup.get(row.topic.subjectId ?? "") ?? null}
-                    timezone={timezone}
-                    zonedNow={zonedNow}
-                    onEdit={() => handleEdit(row.topic.id)}
-                    editing={editingId === row.topic.id}
-                  />
-                ))}
+            <div className="overflow-hidden rounded-xl border border-border/60 bg-card/70">
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-border/50">
+                  <thead className="bg-muted/20 text-xs font-semibold uppercase tracking-wide text-muted-foreground/80">
+                    <tr>
+                      <th scope="col" className="w-[32%] min-w-[200px] px-4 py-3 text-left">
+                        Topic
+                      </th>
+                      <th scope="col" className="w-[20%] min-w-[160px] px-4 py-3 text-left">
+                        Subject
+                      </th>
+                      <th scope="col" className="w-[20%] min-w-[160px] px-4 py-3 text-left">
+                        Next review
+                      </th>
+                      <th scope="col" className="w-[16%] min-w-[140px] px-4 py-3 text-left">
+                        Status
+                      </th>
+                      <th scope="col" className="min-w-[140px] px-4 py-3 text-right">
+                        Actions
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-border/50">
+                    {filteredItems.map((row) => (
+                      <TopicListRow
+                        key={row.topic.id}
+                        item={row}
+                        subject={row.subject ?? subjectLookup.get(row.topic.subjectId ?? "") ?? null}
+                        timezone={timezone}
+                        zonedNow={zonedNow}
+                        onEdit={() => handleEdit(row.topic.id)}
+                        editing={editingId === row.topic.id}
+                      />
+                    ))}
+                  </tbody>
+                </table>
               </div>
             </div>
           )}
@@ -854,6 +873,7 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
   };
 
   const handleReviseNow = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     if (hasUsedReviseToday) {
       trackReviseNowBlocked();
       toast.error(REVISE_LOCKED_MESSAGE);
@@ -915,46 +935,62 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
 
   const nextReviewDateLabel = formatDateWithWeekday(item.topic.nextReviewDate);
   const nextReviewRelativeLabel = formatRelativeToNow(item.topic.nextReviewDate);
+  const detailRowId = `topic-details-${item.topic.id}`;
+  const subjectName = subject ? subject.name : "No subject";
+  const subjectColor = subject?.color ?? FALLBACK_SUBJECT_COLOR;
+
+  const handleRowClick = React.useCallback(() => {
+    setExpanded((value) => !value);
+  }, [setExpanded]);
+
+  const handleRowKeyDown = React.useCallback((event: React.KeyboardEvent<HTMLTableRowElement>) => {
+    if (event.target !== event.currentTarget) return;
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      setExpanded((value) => !value);
+    }
+  }, [setExpanded]);
 
   return (
-    <div className={cn("transition-colors", recentlyRevised ? "bg-success/10" : "bg-transparent")}
-    >
-      <div className="flex flex-col gap-3 px-4 py-4 md:grid md:grid-cols-[minmax(0,2.5fr)_minmax(0,1.2fr)_minmax(0,1.3fr)_minmax(0,1fr)_auto] md:items-center md:gap-4 md:px-6">
-        <div className="flex flex-col gap-2">
+    <>
+      <tr
+        className={cn(
+          "group cursor-pointer align-top transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40",
+          recentlyRevised ? "bg-success/10" : "hover:bg-muted/30"
+        )}
+        onClick={handleRowClick}
+        onKeyDown={handleRowKeyDown}
+        tabIndex={0}
+        role="button"
+        aria-expanded={expanded}
+        aria-controls={detailRowId}
+      >
+        <td className="px-4 py-3 align-top">
           <div className="flex items-start gap-3">
-            <button
-              type="button"
-              onClick={() => setExpanded((value) => !value)}
-              className="mt-0.5 inline-flex h-11 w-11 flex-none items-center justify-center rounded-full border border-inverse/10 bg-inverse/5 text-fg transition hover:bg-inverse/10"
-              aria-expanded={expanded}
-              aria-controls={`topic-details-${item.topic.id}`}
-              title={expanded ? "Hide details" : "Show details"}
+            <span
+              aria-hidden="true"
+              className={cn(
+                "mt-1 inline-flex h-6 w-6 flex-none items-center justify-center rounded-full border border-border/60 bg-muted/20 text-muted-foreground transition-transform",
+                expanded ? "rotate-90 text-primary" : ""
+              )}
             >
-              <ChevronDown
-                className={cn("h-4 w-4 transition-transform", expanded ? "rotate-180" : "")}
-                aria-hidden="true"
-              />
-            </button>
+              <ChevronRight className="h-3.5 w-3.5" />
+            </span>
             <div className="min-w-0 space-y-1">
               <div className="flex flex-wrap items-center gap-2">
-                <p className="truncate text-base font-semibold text-fg" title={item.topic.title}>
+                <span className="truncate text-sm font-semibold text-fg" title={item.topic.title}>
                   {item.topic.title}
-                </p>
+                </span>
                 {editing ? (
-                  <span className="rounded-full bg-inverse/10 px-2 py-0.5 text-[10px] uppercase tracking-wide text-accent">
+                  <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
                     Editing…
                   </span>
                 ) : null}
               </div>
-              <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground md:hidden">
-                <span
-                  className="inline-flex items-center gap-2 rounded-full border border-inverse/10 bg-inverse/5 px-2.5 py-1"
-                  style={{ backgroundColor: `${(subject?.color ?? FALLBACK_SUBJECT_COLOR)}1f` }}
-                >
-                  <span className="flex h-5 w-5 items-center justify-center rounded-full bg-inverse/15 text-fg">
-                    <IconPreview name={subject?.icon ?? "Sparkles"} className="h-3.5 w-3.5" />
-                  </span>
-                  <span>{subject ? subject.name : "No subject"}</span>
+              <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground md:hidden">
+                <span className="inline-flex items-center gap-1">
+                  <span className="h-2 w-2 rounded-full" style={{ backgroundColor: subjectColor }} />
+                  {subjectName}
                 </span>
                 <span className="inline-flex items-center gap-1">
                   <CalendarClock className="h-3 w-3" aria-hidden="true" /> {nextReviewRelativeLabel}
@@ -966,140 +1002,153 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
               </div>
             </div>
           </div>
-        </div>
-        <div className="hidden min-w-0 items-center gap-2 text-sm text-fg/80 md:flex">
-          <span
-            className="inline-flex items-center gap-2 rounded-full border border-inverse/10 bg-inverse/5 px-3 py-1 text-xs font-medium"
-            style={{ backgroundColor: `${(subject?.color ?? FALLBACK_SUBJECT_COLOR)}1f` }}
-          >
-            <span className="flex h-5 w-5 items-center justify-center rounded-full bg-inverse/15 text-fg">
-              <IconPreview name={subject?.icon ?? "Sparkles"} className="h-3.5 w-3.5" />
-            </span>
-            {subject ? subject.name : "No subject"}
-          </span>
-        </div>
-        <div className="hidden min-w-0 flex-col text-sm text-inverse md:flex">
-          <span className="font-medium text-fg">{nextReviewDateLabel}</span>
-          <span className="text-xs text-muted-foreground">{nextReviewRelativeLabel}</span>
-        </div>
-        <div className="hidden md:flex">
+        </td>
+        <td className="hidden px-4 py-3 align-top text-sm text-muted-foreground md:table-cell">
+          <div className="flex items-center gap-2 truncate">
+            <span className="h-2 w-2 rounded-full" style={{ backgroundColor: subjectColor }} />
+            <span className="truncate">{subjectName}</span>
+          </div>
+        </td>
+        <td className="hidden px-4 py-3 align-top md:table-cell">
+          <div className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-fg">{nextReviewDateLabel}</span>
+            <span className="text-xs text-muted-foreground">{nextReviewRelativeLabel}</span>
+          </div>
+        </td>
+        <td className="hidden px-4 py-3 align-top lg:table-cell">
           <span
             className={cn(
-              "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs",
+              "inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs font-semibold",
               statusMeta.badgeClass
             )}
           >
             {statusMeta.icon}
             {statusMeta.label}
           </span>
-        </div>
-        <div className="flex items-center justify-end gap-3">
-          <Button
-            size="lg"
-            onClick={(event) => handleReviseNow(event)}
-            disabled={hasUsedReviseToday || isLoggingRevision}
-            className="min-w-[6.5rem] rounded-full px-5"
-            title={hasUsedReviseToday ? nextAvailabilityMessage : "Log today’s revision"}
-            aria-label={hasUsedReviseToday ? "Revise locked until after midnight" : "Log today’s revision"}
-            aria-describedby={hasUsedReviseToday ? lockedDescriptionId : undefined}
-          >
-            Revise
-          </Button>
-          <Button
-            size="icon"
-            variant="ghost"
-            onClick={onEdit}
-            title="Edit topic"
-            aria-label="Edit topic"
-            className="h-11 w-11 rounded-full text-muted-foreground hover:text-fg"
-          >
-            <Pencil className="h-4 w-4" />
-          </Button>
-          <Popover>
-            <PopoverTrigger asChild>
+        </td>
+        <td className="px-4 py-3 align-top">
+          <div className="flex flex-col items-end gap-2">
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <Button
+                size="sm"
+                onClick={handleReviseNow}
+                disabled={hasUsedReviseToday || isLoggingRevision}
+                className="rounded-full px-4"
+                title={hasUsedReviseToday ? nextAvailabilityMessage : "Log today’s revision"}
+                aria-label={hasUsedReviseToday ? "Revise locked until after midnight" : "Log today’s revision"}
+                aria-describedby={hasUsedReviseToday ? lockedDescriptionId : undefined}
+              >
+                Revise
+              </Button>
               <Button
                 size="icon"
                 variant="ghost"
-                className="h-11 w-11 rounded-full text-muted-foreground hover:text-fg"
-                title="More actions"
-                aria-label="More topic actions"
-              >
-                <Ellipsis className="h-4 w-4" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-48 rounded-2xl border border-inverse/10 bg-card/95 p-2 text-sm text-fg">
-              <button
-                type="button"
-                onClick={() => {
-                  setShowSkipConfirm(true);
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onEdit();
                 }}
-                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-fg/80 transition hover:bg-inverse/10"
+                title="Edit topic"
+                aria-label="Edit topic"
+                className="h-9 w-9 rounded-full text-muted-foreground hover:text-fg"
               >
-                <RefreshCw className="h-4 w-4" aria-hidden="true" /> Skip today
-              </button>
-              <button
-                type="button"
-                onClick={() => setShowDeleteConfirm(true)}
-                className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-error/20 transition hover:bg-error/20"
-              >
-                <Trash2 className="h-4 w-4" aria-hidden="true" /> Delete topic
-              </button>
-            </PopoverContent>
-          </Popover>
-        </div>
-      </div>
-      {hasUsedReviseToday ? (
-        <>
-          <p className="px-6 text-[11px] text-muted-foreground/80 md:text-right">{nextAvailabilitySubtext}</p>
-          <span id={lockedDescriptionId} className="sr-only">
-            {nextAvailabilityMessage}
-          </span>
-        </>
-      ) : null}
-      {expanded ? (
-        <div
-          id={`topic-details-${item.topic.id}`}
-          className="border-t border-inverse/5 bg-bg/40 px-4 py-4 text-sm text-muted-foreground md:px-6"
-        >
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Schedule</p>
-              <ul className="space-y-1 text-xs text-muted-foreground">
-                <li>
-                  <span className="text-muted-foreground">Reminder:</span> {reminderLabel}
-                </li>
-                <li>
-                  <span className="text-muted-foreground">Intervals:</span> {intervalsLabel}
-                </li>
-                <li>
-                  <span className="text-muted-foreground">Last reviewed:</span> {lastReviewedLabel}
-                </li>
-                <li>
-                  <span className="text-muted-foreground">Total reviews:</span> {totalReviews}
-                </li>
-                {examDateLabel ? (
-                  <li>
-                    <span className="text-muted-foreground">Exam:</span> {examDateLabel}
-                    {typeof daysUntilExam === "number" ? ` • ${daysUntilExam} day${daysUntilExam === 1 ? "" : "s"} left` : ""}
-                  </li>
-                ) : null}
-              </ul>
+                <Pencil className="h-4 w-4" />
+              </Button>
+              <Popover>
+                <PopoverTrigger asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    onClick={(event) => event.stopPropagation()}
+                    className="h-9 w-9 rounded-full text-muted-foreground hover:text-fg"
+                    title="More actions"
+                    aria-label="More topic actions"
+                  >
+                    <Ellipsis className="h-4 w-4" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-48 rounded-xl border border-border/60 bg-card/95 p-2 text-sm text-fg shadow-lg">
+                  {item.status === "due-today" ? (
+                    <button
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setShowSkipConfirm(true);
+                      }}
+                      className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-muted-foreground transition hover:bg-muted/30 hover:text-foreground"
+                    >
+                      <RefreshCw className="h-4 w-4" aria-hidden="true" /> Skip today
+                    </button>
+                  ) : null}
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setShowDeleteConfirm(true);
+                    }}
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-error/80 transition hover:bg-error/10"
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" /> Delete topic
+                  </button>
+                </PopoverContent>
+              </Popover>
             </div>
-            <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</p>
-              <p className="whitespace-pre-line text-xs text-fg/80">{notesPreview}</p>
-              {notes.length > 180 ? (
-                <button
-                  type="button"
-                  onClick={() => setShowFullNotes((value) => !value)}
-                  className="text-xs font-semibold text-accent hover:underline"
-                >
-                  {showFullNotes ? "Show less" : "View more"}
-                </button>
-              ) : null}
-            </div>
+            {hasUsedReviseToday ? (
+              <>
+                <p className="text-[11px] text-muted-foreground">{nextAvailabilitySubtext}</p>
+                <span id={lockedDescriptionId} className="sr-only">
+                  {nextAvailabilityMessage}
+                </span>
+              </>
+            ) : null}
           </div>
-        </div>
+        </td>
+      </tr>
+      {expanded ? (
+        <tr id={detailRowId} className="bg-muted/15 text-sm text-muted-foreground">
+          <td colSpan={5} className="px-4 py-4">
+            <div className="grid gap-6 md:grid-cols-2">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Schedule</p>
+                <ul className="space-y-1 text-xs text-muted-foreground">
+                  <li>
+                    <span className="text-muted-foreground">Reminder:</span> {reminderLabel}
+                  </li>
+                  <li>
+                    <span className="text-muted-foreground">Intervals:</span> {intervalsLabel}
+                  </li>
+                  <li>
+                    <span className="text-muted-foreground">Last reviewed:</span> {lastReviewedLabel}
+                  </li>
+                  <li>
+                    <span className="text-muted-foreground">Total reviews:</span> {totalReviews}
+                  </li>
+                  {examDateLabel ? (
+                    <li>
+                      <span className="text-muted-foreground">Exam:</span> {examDateLabel}
+                      {typeof daysUntilExam === "number" ? ` • ${daysUntilExam} day${daysUntilExam === 1 ? "" : "s"} left` : ""}
+                    </li>
+                  ) : null}
+                </ul>
+              </div>
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</p>
+                <p className="whitespace-pre-line text-xs text-fg/80">{notesPreview}</p>
+                {notes.length > 180 ? (
+                  <button
+                    type="button"
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      setShowFullNotes((value) => !value);
+                    }}
+                    className="text-xs font-semibold text-accent hover:underline"
+                  >
+                    {showFullNotes ? "Show less" : "View more"}
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          </td>
+        </tr>
       ) : null}
 
       <ConfirmationDialog
@@ -1177,6 +1226,6 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
             : null
         ].filter(Boolean) as { label: string; action: () => void }[]}
       />
-    </div>
+    </>
   );
 }

--- a/src/components/forms/topic-form.tsx
+++ b/src/components/forms/topic-form.tsx
@@ -42,6 +42,7 @@ import { AutoAdjustPreference, Subject } from "@/types/topic";
 import { daysBetween, formatFullDate } from "@/lib/date";
 
 import { IconPreview } from "@/components/icon-preview";
+import { useReviewPreferencesStore } from "@/stores/review-preferences";
 
 
 
@@ -272,6 +273,8 @@ export const TopicForm: React.FC<TopicFormProps> = ({ topicId = null, onSubmitCo
     topics: state.topics
 
   }));
+
+  const reviewTrigger = useReviewPreferencesStore((state) => state.reviewTrigger);
 
 
 
@@ -675,7 +678,9 @@ export const TopicForm: React.FC<TopicFormProps> = ({ topicId = null, onSubmitCo
 
       intervals: intervals.length > 0 ? intervals : [...defaultIntervals],
 
-      autoAdjustPreference
+      autoAdjustPreference,
+
+      retrievabilityTarget: reviewTrigger
 
     };
 

--- a/src/components/ui/status-badge.tsx
+++ b/src/components/ui/status-badge.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import * as React from "react";
+import { CalendarClock, CalendarDays, AlertTriangle } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type StatusBadgeType = "exam" | "upcoming" | "overdue";
+
+interface StatusBadgeConfig {
+  className: string;
+  icon: LucideIcon;
+  getAriaLabel?: (label: string, date?: string) => string;
+}
+
+const baseBadgeClass =
+  "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-wide transition-all duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2";
+
+const statusConfig: Record<StatusBadgeType, StatusBadgeConfig> = {
+  exam: {
+    className:
+      "bg-amber-100 text-amber-700 border-amber-300 hover:bg-amber-200 focus-visible:ring-amber-400/60 dark:bg-amber-900/40 dark:text-amber-300 dark:border-amber-700/60 dark:hover:bg-amber-800/60", 
+    icon: CalendarClock,
+    getAriaLabel: (label, date) => (date ? `Exam date: ${label}` : `Exam status: ${label}`)
+  },
+  upcoming: {
+    className:
+      "bg-sky-100 text-sky-700 border-sky-300 hover:bg-sky-200 focus-visible:ring-sky-400/60 dark:bg-sky-900/40 dark:text-sky-300 dark:border-sky-700/60 dark:hover:bg-sky-800/60",
+    icon: CalendarDays,
+    getAriaLabel: (label) => `Upcoming status: ${label}`
+  },
+  overdue: {
+    className:
+      "bg-rose-100 text-rose-700 border-rose-300 hover:bg-rose-200 focus-visible:ring-rose-400/60 dark:bg-rose-900/40 dark:text-rose-300 dark:border-rose-700/60 dark:hover:bg-rose-800/60",
+    icon: AlertTriangle,
+    getAriaLabel: (label) => `Overdue status: ${label}`
+  }
+};
+
+export interface StatusBadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  type: StatusBadgeType;
+  label: string;
+  date?: string;
+  icon?: LucideIcon;
+}
+
+export const StatusBadge = React.forwardRef<HTMLSpanElement, StatusBadgeProps>(function StatusBadge(
+  props,
+  ref
+) {
+  const {
+    type,
+    label,
+    date,
+    icon: IconOverride,
+    className,
+    role,
+    tabIndex,
+    ["aria-label"]: ariaLabelProp,
+    ...rest
+  } = props;
+
+  const config = statusConfig[type];
+  const Icon = IconOverride ?? config.icon;
+  const ariaLabel = ariaLabelProp ?? config.getAriaLabel?.(label, date) ?? label;
+
+  return (
+    <span
+      {...rest}
+      ref={ref}
+      role={role ?? "status"}
+      aria-label={ariaLabel}
+      aria-live="polite"
+      tabIndex={tabIndex ?? 0}
+      className={cn(baseBadgeClass, config.className, className)}
+    >
+      {Icon ? <Icon className="h-3.5 w-3.5" aria-hidden="true" /> : null}
+      <span>{label}</span>
+    </span>
+  );
+});

--- a/src/lib/adaptive-scheduler.ts
+++ b/src/lib/adaptive-scheduler.ts
@@ -1,0 +1,119 @@
+import {
+  DAY_MS,
+  DEFAULT_RETENTION_FLOOR,
+  REVIEW_TRIGGER_MAX,
+  REVIEW_TRIGGER_MIN,
+  STABILITY_MAX_DAYS,
+  STABILITY_MIN_DAYS,
+  computeIntervalDays,
+  computeRetrievability
+} from "@/lib/forgetting-curve";
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+export const DEFAULT_GROWTH_ALPHA = 0.25;
+export const DEFAULT_LAPSE_BETA = 0.15;
+export const MAX_PROJECTED_REVIEWS = 48;
+
+export interface AdaptiveScheduleOptions {
+  /** Date of the last successful review (or topic start). */
+  anchorDate: Date;
+  /** Current stability in days. */
+  stabilityDays: number;
+  /** Reviews logged so far. */
+  reviewsCount: number;
+  /** Target retention threshold (0-1). */
+  reviewTrigger: number;
+  /** Optional exam cap; schedule stops before this. */
+  examDate?: Date | null;
+  /** Maximum reviews to project (failsafe). */
+  maxReviews?: number;
+  /** Custom alpha for stability growth. */
+  alpha?: number;
+  /** Custom beta for lapse penalty. */
+  beta?: number;
+  /** Number of consecutive lapses to model. */
+  lapses?: number;
+  /** Retention floor. */
+  floor?: number;
+}
+
+export interface AdaptiveReviewCheckpoint {
+  index: number;
+  /** ISO string for the scheduled review date. */
+  date: string;
+  /** Interval in days leading to this review. */
+  intervalDays: number;
+  /** Projected stability immediately after this review. */
+  stabilityDays: number;
+  /** Retention right before the review. */
+  retention: number;
+}
+
+const applyLapsePenalty = (stabilityDays: number, beta: number, lapses: number) => {
+  let next = stabilityDays;
+  for (let index = 0; index < lapses; index += 1) {
+    next *= 1 - beta;
+  }
+  return clamp(next, STABILITY_MIN_DAYS, STABILITY_MAX_DAYS);
+};
+
+export const projectAdaptiveSchedule = ({
+  anchorDate,
+  stabilityDays,
+  reviewsCount,
+  reviewTrigger,
+  examDate,
+  maxReviews = MAX_PROJECTED_REVIEWS,
+  alpha = DEFAULT_GROWTH_ALPHA,
+  beta = DEFAULT_LAPSE_BETA,
+  lapses = 0,
+  floor = DEFAULT_RETENTION_FLOOR
+}: AdaptiveScheduleOptions): AdaptiveReviewCheckpoint[] => {
+  const trigger = clamp(reviewTrigger, REVIEW_TRIGGER_MIN, REVIEW_TRIGGER_MAX);
+  const effectiveAlpha = Math.max(0, alpha);
+  const effectiveBeta = clamp(beta, 0, 1);
+  const anchorMs = anchorDate.getTime();
+  const examMs = examDate ? examDate.getTime() : null;
+
+  let stability = clamp(stabilityDays, STABILITY_MIN_DAYS, STABILITY_MAX_DAYS);
+  let count = Math.max(0, reviewsCount);
+  let currentMs = anchorMs;
+  let remainingLapses = Math.max(0, Math.floor(lapses));
+
+  const checkpoints: AdaptiveReviewCheckpoint[] = [];
+
+  for (let iteration = 0; iteration < maxReviews; iteration += 1) {
+    const intervalDays = computeIntervalDays(stability, trigger);
+    const intervalMs = intervalDays * DAY_MS;
+    const scheduledMs = currentMs + intervalMs;
+    if (examMs && scheduledMs > examMs) {
+      break;
+    }
+
+    const retention = computeRetrievability(stability, intervalMs, floor);
+    const scheduledDate = new Date(scheduledMs);
+    checkpoints.push({
+      index: count + 1,
+      date: scheduledDate.toISOString(),
+      intervalDays,
+      stabilityDays: stability,
+      retention
+    });
+
+    currentMs = scheduledMs;
+    count += 1;
+    stability = clamp(stability * (1 + effectiveAlpha), STABILITY_MIN_DAYS, STABILITY_MAX_DAYS);
+    if (remainingLapses > 0) {
+      stability = applyLapsePenalty(stability, effectiveBeta, 1);
+      remainingLapses -= 1;
+    }
+  }
+
+  return checkpoints;
+};
+
+export const computeNextAdaptiveReview = (options: AdaptiveScheduleOptions): AdaptiveReviewCheckpoint | null => {
+  const schedule = projectAdaptiveSchedule({ ...options, maxReviews: Math.min(options.maxReviews ?? 1, 1) });
+  return schedule[0] ?? null;
+};

--- a/src/lib/export-svg.ts
+++ b/src/lib/export-svg.ts
@@ -10,43 +10,74 @@ export const downloadSvg = (svg: SVGSVGElement, filename = "timeline.svg") => {
   URL.revokeObjectURL(link.href);
 };
 
-export const downloadSvgAsPng = async (svg: SVGSVGElement, filename = "timeline.png") => {
+const sanitizeSvgClone = (clone: SVGSVGElement) => {
+  const walker = document.createTreeWalker(clone, NodeFilter.SHOW_ELEMENT);
+  while (walker.nextNode()) {
+    const element = walker.currentNode as Element;
+    if (element.hasAttribute("filter")) {
+      element.removeAttribute("filter");
+    }
+    if (element.tagName.toLowerCase() === "image") {
+      element.removeAttribute("href");
+      element.removeAttribute("xlink:href");
+    }
+  }
+};
+
+export const downloadSvgAsPng = async (svg: SVGSVGElement, filename = "timeline.png"): Promise<boolean> => {
   const clone = svg.cloneNode(true) as SVGSVGElement;
   clone.setAttribute("xmlns", "http://www.w3.org/2000/svg");
+  sanitizeSvgClone(clone);
+
   const data = new XMLSerializer().serializeToString(clone);
   const svgBlob = new Blob([data], { type: "image/svg+xml;charset=utf-8" });
   const url = URL.createObjectURL(svgBlob);
 
-  const image = new Image();
-  const rect = svg.getBoundingClientRect();
-  const widthAttr = svg.getAttribute("width");
-  const heightAttr = svg.getAttribute("height");
-  const width = rect.width || (widthAttr ? Number.parseFloat(widthAttr) : 0);
-  const height = rect.height || (heightAttr ? Number.parseFloat(heightAttr) : 0);
-  if (!width || !height) {
+  try {
+    const image = new Image();
+    image.crossOrigin = "anonymous";
+
+    const rect = svg.getBoundingClientRect();
+    const widthAttr = svg.getAttribute("width");
+    const heightAttr = svg.getAttribute("height");
+    const width = rect.width || (widthAttr ? Number.parseFloat(widthAttr) : 0);
+    const height = rect.height || (heightAttr ? Number.parseFloat(heightAttr) : 0);
+    if (!width || !height) {
+      return false;
+    }
+
+    const canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      return false;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      image.onload = () => resolve();
+      image.onerror = () => reject(new Error("image-load-failed"));
+      image.src = url;
+    });
+
+    context.drawImage(image, 0, 0, width, height);
+
+    let dataUrl: string;
+    try {
+      dataUrl = canvas.toDataURL("image/png");
+    } catch (error) {
+      return false;
+    }
+
+    const link = document.createElement("a");
+    link.href = dataUrl;
+    link.download = filename;
+    link.click();
+    return true;
+  } catch (error) {
+    console.error("Failed to export SVG as PNG", error);
+    return false;
+  } finally {
     URL.revokeObjectURL(url);
-    return;
   }
-
-  const canvas = document.createElement("canvas");
-  canvas.width = width;
-  canvas.height = height;
-  const context = canvas.getContext("2d");
-  if (!context) {
-    URL.revokeObjectURL(url);
-    return;
-  }
-
-  await new Promise<void>((resolve) => {
-    image.onload = () => resolve();
-    image.src = url;
-  });
-
-  context.drawImage(image, 0, 0, width, height);
-  URL.revokeObjectURL(url);
-
-  const link = document.createElement("a");
-  link.href = canvas.toDataURL("image/png");
-  link.download = filename;
-  link.click();
 };

--- a/src/lib/forgetting-curve.ts
+++ b/src/lib/forgetting-curve.ts
@@ -1,6 +1,8 @@
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
-export const DEFAULT_RETRIEVABILITY_TARGET = 0.7;
+export const DEFAULT_RETRIEVABILITY_TARGET = 0.5;
+export const REVIEW_TRIGGER_MIN = 0.3;
+export const REVIEW_TRIGGER_MAX = 0.8;
 export const DEFAULT_STABILITY_DAYS = 1;
 export const STABILITY_MIN_DAYS = 0.25;
 export const STABILITY_MAX_DAYS = 3650;

--- a/src/stores/review-preferences.ts
+++ b/src/stores/review-preferences.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+import { DEFAULT_GROWTH_ALPHA, DEFAULT_LAPSE_BETA } from "@/lib/adaptive-scheduler";
+import {
+  DEFAULT_RETRIEVABILITY_TARGET,
+  REVIEW_TRIGGER_MAX,
+  REVIEW_TRIGGER_MIN
+} from "@/lib/forgetting-curve";
+import { useTopicStore } from "@/stores/topics";
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+export type AdaptiveMode = "adaptive" | "fixed";
+
+type ReviewPreferencesState = {
+  mode: AdaptiveMode;
+  reviewTrigger: number;
+  alpha: number;
+  beta: number;
+  setMode: (mode: AdaptiveMode) => void;
+  setReviewTrigger: (value: number) => void;
+  setAlpha: (value: number) => void;
+  setBeta: (value: number) => void;
+};
+
+const applyTriggerToTopics = (trigger: number) => {
+  const apply = useTopicStore.getState().applyReviewTrigger;
+  if (typeof apply === "function") {
+    apply(trigger);
+  }
+};
+
+export const useReviewPreferencesStore = create<ReviewPreferencesState>()(
+  persist(
+    (set) => ({
+      mode: "adaptive",
+      reviewTrigger: DEFAULT_RETRIEVABILITY_TARGET,
+      alpha: DEFAULT_GROWTH_ALPHA,
+      beta: DEFAULT_LAPSE_BETA,
+      setMode: (mode) =>
+        set((state) => {
+          if (mode === "adaptive") {
+            applyTriggerToTopics(state.reviewTrigger);
+          }
+          return { mode };
+        }),
+      setReviewTrigger: (value) => {
+        const clamped = clamp(value, REVIEW_TRIGGER_MIN, REVIEW_TRIGGER_MAX);
+        set({ reviewTrigger: clamped, mode: "adaptive" });
+        applyTriggerToTopics(clamped);
+      },
+      setAlpha: (value) => set({ alpha: Math.max(0, value) }),
+      setBeta: (value) => set({ beta: clamp(value, 0, 1) })
+    }),
+    {
+      name: "adaptive-review-preferences",
+      version: 1,
+      onRehydrateStorage: () => (state, error) => {
+        if (error) return;
+        const trigger = state?.reviewTrigger ?? DEFAULT_RETRIEVABILITY_TARGET;
+        applyTriggerToTopics(trigger);
+      }
+    }
+  )
+);
+
+export const getReviewPreferencesState = () => useReviewPreferencesStore.getState();

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -16,6 +16,15 @@ body.dark * {
   border-color: #262a30;
 }
 
+.scrollbar-none {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.scrollbar-none::-webkit-scrollbar {
+  display: none;
+}
+
 body.light .icon {
   color: #9aa0a6;
 }
@@ -44,6 +53,18 @@ body.light :where(p, span, label) {
 
 body.light :where(small, .muted) {
     color: #555555;
+  }
+
+body.dark :where(h1, h2, h3, h4) {
+    color: #f4f4f5;
+  }
+
+body.dark :where(p, span, label) {
+    color: #d4d4d8;
+  }
+
+body.dark :where(small, .muted) {
+    color: #a1a1aa;
   }
 
 /* background surfaces */
@@ -117,6 +138,13 @@ body.light .bg-accent\/25 { background-color: rgba(33, 206, 153, 0.25); }
 body.dark .bg-accent\/25 { background-color: rgba(61, 234, 149, 0.25); }
 body.light .bg-accent\/90 { background-color: rgba(33, 206, 153, 0.9); }
 body.dark .bg-accent\/90 { background-color: rgba(61, 234, 149, 0.9); }
+
+body.light .bg-primary\/10 { background-color: rgba(33, 206, 153, 0.1); }
+body.dark .bg-primary\/10 { background-color: rgba(61, 234, 149, 0.1); }
+body.light .bg-primary\/15 { background-color: rgba(33, 206, 153, 0.15); }
+body.dark .bg-primary\/15 { background-color: rgba(61, 234, 149, 0.15); }
+body.light .hover\:bg-primary\/15:hover { background-color: rgba(33, 206, 153, 0.15); }
+body.dark .hover\:bg-primary\/15:hover { background-color: rgba(61, 234, 149, 0.15); }
 
 /* subject revision tables */
 .subject-table-card {
@@ -361,6 +389,8 @@ body.light .bg-success\/20 { background-color: rgba(33, 206, 153, 0.2); }
 body.dark .bg-success\/20 { background-color: rgba(61, 234, 149, 0.2); }
 body.light .bg-success\/80 { background-color: rgba(33, 206, 153, 0.8); }
 body.dark .bg-success\/80 { background-color: rgba(61, 234, 149, 0.8); }
+body.light .text-success { color: #21ce99; }
+body.dark .text-success { color: #3dea95; }
 
 body.light .bg-warn { background-color: #f5a623; }
 body.dark .bg-warn { background-color: #f5a623; }
@@ -372,26 +402,32 @@ body.light .bg-warn\/20 { background-color: rgba(245, 166, 35, 0.2); }
 body.dark .bg-warn\/20 { background-color: rgba(245, 166, 35, 0.2); }
 body.light .bg-warn\/80 { background-color: rgba(245, 166, 35, 0.8); }
 body.dark .bg-warn\/80 { background-color: rgba(245, 166, 35, 0.8); }
+body.light .text-warn { color: #f5a623; }
+body.dark .text-warn { color: #f5a623; }
 
 body.light .bg-error { background-color: #e5484d; }
 body.dark .bg-error { background-color: #f87171; }
 body.light .bg-error\/20 { background-color: rgba(229, 72, 77, 0.2); }
 body.dark .bg-error\/20 { background-color: rgba(248, 113, 113, 0.2); }
+body.light .text-error { color: #e5484d; }
+body.dark .text-error { color: #f87171; }
 
 /* text colors */
 body.light .text-fg { color: #1a1a1a; }
-body.dark .text-fg { color: #ffffff; }
+body.dark .text-fg { color: #eaeaea; }
 body.light .text-fg\/70 { color: rgba(26, 26, 26, 0.7); }
-body.dark .text-fg\/70 { color: rgba(255, 255, 255, 0.7); }
+body.dark .text-fg\/70 { color: rgba(234, 234, 234, 0.7); }
 body.light .text-fg\/80 { color: rgba(26, 26, 26, 0.8); }
-body.dark .text-fg\/80 { color: rgba(255, 255, 255, 0.8); }
+body.dark .text-fg\/80 { color: rgba(234, 234, 234, 0.8); }
 body.light .text-fg\/90 { color: rgba(26, 26, 26, 0.9); }
-body.dark .text-fg\/90 { color: rgba(255, 255, 255, 0.9); }
+body.dark .text-fg\/90 { color: rgba(234, 234, 234, 0.9); }
 
 body.light .text-muted-foreground { color: #999999; }
-body.dark .text-muted-foreground { color: #808080; }
+body.dark .text-muted-foreground { color: #d4d4d8; }
 body.light .text-muted-foreground\/80 { color: rgba(153, 153, 153, 0.8); }
-body.dark .text-muted-foreground\/80 { color: rgba(128, 128, 128, 0.8); }
+body.dark .text-muted-foreground\/80 { color: rgba(212, 212, 216, 0.8); }
+body.light .text-muted-foreground\/70 { color: rgba(153, 153, 153, 0.7); }
+body.dark .text-muted-foreground\/70 { color: rgba(212, 212, 216, 0.7); }
 
 body.light .text-accent { color: #21ce99; }
 body.dark .text-accent { color: #3dea95; }
@@ -402,10 +438,23 @@ body.dark .text-accent\/30 { color: rgba(61, 234, 149, 0.3); }
 body.light .text-accent\/80 { color: rgba(33, 206, 153, 0.8); }
 body.dark .text-accent\/80 { color: rgba(61, 234, 149, 0.8); }
 
+body.light ::placeholder {
+  color: #6b7280;
+  opacity: 1;
+}
+
+body.dark ::placeholder {
+  color: #9ca3af;
+  opacity: 1;
+}
+
 body.light .text-accent-foreground { color: #ffffff; }
 body.dark .text-accent-foreground { color: #0f1115; }
 body.light .text-accent-foreground\/80 { color: rgba(255, 255, 255, 0.8); }
 body.dark .text-accent-foreground\/80 { color: rgba(15, 17, 21, 0.8); }
+
+body.light .text-primary { color: #0f766e; }
+body.dark .text-primary { color: #5eead4; }
 
 body.light .text-success\/20 { color: rgba(33, 206, 153, 0.2); }
 body.dark .text-success\/20 { color: rgba(61, 234, 149, 0.2); }
@@ -453,6 +502,9 @@ body.dark .border-accent\/30 { border-color: rgba(61, 234, 149, 0.3); }
 body.light .border-accent\/40 { border-color: rgba(33, 206, 153, 0.4); }
 body.dark .border-accent\/40 { border-color: rgba(61, 234, 149, 0.4); }
 
+body.light .border-primary { border-color: rgba(15, 118, 110, 0.6); }
+body.dark .border-primary { border-color: rgba(94, 234, 212, 0.6); }
+
 body.light .border-success\/20 { border-color: rgba(33, 206, 153, 0.2); }
 body.dark .border-success\/20 { border-color: rgba(61, 234, 149, 0.2); }
 body.light .border-success\/40 { border-color: rgba(33, 206, 153, 0.4); }
@@ -484,6 +536,11 @@ body.light .ring-accent\/60 { --tw-ring-color: rgba(33, 206, 153, 0.6); }
 body.dark .ring-accent\/60 { --tw-ring-color: rgba(61, 234, 149, 0.6); }
 body.light .ring-accent\/80 { --tw-ring-color: rgba(33, 206, 153, 0.8); }
 body.dark .ring-accent\/80 { --tw-ring-color: rgba(61, 234, 149, 0.8); }
+
+body.light .ring-primary\/50 { --tw-ring-color: rgba(15, 118, 110, 0.5); }
+body.dark .ring-primary\/50 { --tw-ring-color: rgba(94, 234, 212, 0.5); }
+body.light .focus-visible\:ring-primary\/50:focus-visible { --tw-ring-color: rgba(15, 118, 110, 0.5); }
+body.dark .focus-visible\:ring-primary\/50:focus-visible { --tw-ring-color: rgba(94, 234, 212, 0.5); }
 
 body.light .ring-success\/40 { --tw-ring-color: rgba(33, 206, 153, 0.4); }
 body.dark .ring-success\/40 { --tw-ring-color: rgba(61, 234, 149, 0.4); }
@@ -694,12 +751,10 @@ body.dark .checkpoint-status--scheduled {
   }
 
 body.light .subject-exam-info {
-    color: #333333;
     font-weight: 500;
   }
 
 body.dark .subject-exam-info {
-    color: #d1d5db;
     font-weight: 500;
   }
 
@@ -714,13 +769,11 @@ body.dark .subject-exam-soon {
   }
 
 body.light .subject-exam-far {
-    color: #2563eb;
-    font-weight: 600;
+    font-weight: 500;
   }
 
 body.dark .subject-exam-far {
-    color: #8ab4ff;
-    font-weight: 600;
+    font-weight: 500;
   }
 
 /* reviews page */
@@ -785,12 +838,3 @@ body.dark .review-motivation {
     font-weight: 500;
   }
 
-body.light .exam-date {
-    color: #2563eb;
-    font-weight: 600;
-  }
-
-body.dark .exam-date {
-    color: #8ab4ff;
-    font-weight: 600;
-  }


### PR DESCRIPTION
## Summary
- streamline the timeline toolbar into icon toggles with a combined milestones control and lighter hover styling
- focus the timeline on a single subject at a time with chips, chart badges, and curve isolation on click
- harden SVG/PNG exports against tainted canvases and document the new behaviour across guidelines and testing notes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e25172339883319f1dc7d34671e215