### PR TITLE
Redesign dashboard summary card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@
 - Added soft divider rules above and below the progress module to separate major dashboard sections.
 - Balanced spacing and headings to match surrounding sections in both light and dark themes.
 
+### UI: Dashboard Summary Card Redesign
+- Merged “Today’s Tasks” and “Progress Today” into a unified overview card.
+- Added icons, emojis, and hover effects for engagement.
+- Improved light/dark mode contrast.
+- Progress indicator and motivational text are now contextually linked.
+
 ### Reviews Page Enhancements
 - Fixed the runtime error triggered by the "All" filter by guarding invalid status lookups.
 - Limited the “Skip today” shortcut to topics due today while keeping other actions available.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@
 - Balanced stroke weights for all icons.
 - Enhanced keyboard focus and tooltips.
 
+### Settings & Appearance Controls
+- Added an appearance panel to tune surface overlay opacity with live preview.
+- Surface overlays across dashboard cards now respect a shared opacity variable persisted per user.
+
+### UI: Dropdown Background Opacity Fix
+- Replaced semi-transparent dropdown surfaces with solid backgrounds for improved readability.
+- Added theme-aware borders, hover tints, and shadows to popovers and select menus.
+- Unified Radix dropdown styling via shared tokens for light and dark modes.
+
 ### Dashboard UI & Chart Refinements
 - Default the dashboard status filter to "Due today" and persist the preference across sessions.
 - Unify the filter button group with uppercase primary styling, horizontal scroll, and accessible focus rings.

--- a/DASHBOARD_UI_GUIDE.md
+++ b/DASHBOARD_UI_GUIDE.md
@@ -1,0 +1,21 @@
+# Dashboard UI Guide
+
+## Dashboard Summary
+- Combines motivational copy, upcoming topic context, and daily metrics into a single `dashboard-summary-card`.
+- Left column surfaces the 🗓️ Today’s Tasks heading, 💡 motivational line, and “Next up” context.
+- Right column highlights streak and overall progress percentage for immediate reinforcement.
+
+## Metrics Grid
+- Four interactive tiles (Due Today, Upcoming, Streak, Progress) present key counts with icons.
+- Cards use subtle hover transitions (bg-card/80, shadow-primary/30) and scale effects on icons.
+- Values inherit semantic color tokens (`status-text` classes, `text-accent`, `text-success`) for theme-safe contrast.
+
+## Progress Summary
+- 📈 Progress message reinforces completion percent with contextual encouragement.
+- Linear accent bar animates width changes for responsive feedback.
+- Tooltip/title copy explains completion totals (e.g., “0 of 31 topics completed today”).
+
+## Responsiveness
+- Desktop layout uses two columns: left (motivation + context) and right (streak/progress overview).
+- Mobile stacks sections with `gap-4` spacing while preserving hover/focus affordances.
+- Metric cards remain touch-friendly with generous padding and rounded corners.

--- a/UI_STYLE_GUIDE.md
+++ b/UI_STYLE_GUIDE.md
@@ -1,4 +1,4 @@
-# UI Style Guide
+﻿# UI Style Guide
 
 ## Icon Buttons
 
@@ -9,3 +9,14 @@ Icon buttons now use unified visual hierarchy:
 - Smooth color transitions on hover and focus
 - Ensure colors use theme tokens to maintain accessibility contrast >= 4.5:1.
 - Accent glow reinforces active states while keeping edges smooth.
+
+## Surface Overlays
+
+- Card-based surfaces use the global --surface-overlay-alpha token (default 10%).
+- Update the Appearance setting to preview different opacity levels across the UI.
+
+## Dropdown Menus
+
+- Use the shared dropdown-surface class for popovers, selects, and menus to ensure fully opaque backgrounds.
+- Hover states tint the background via color-mix and should retain clear text contrast in both themes.
+- Avoid re-adding translucent g-card/xx classes; rely on the theme tokens for border, shadow, and hover behavior.

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,6 +3,10 @@
 import * as React from "react";
 import { useProfileStore } from "@/stores/profile";
 import { useReviewPreferencesStore } from "@/stores/review-preferences";
+import {
+  DEFAULT_SURFACE_OVERLAY_OPACITY,
+  useAppearanceStore
+} from "@/stores/appearance";
 import { useTopicStore } from "@/stores/topics";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -29,6 +33,9 @@ export default function SettingsPage() {
   const setMode = useReviewPreferencesStore((state) => state.setMode);
   const setReviewTrigger = useReviewPreferencesStore((state) => state.setReviewTrigger);
   const triggerPercent = Math.round(reviewTrigger * 100);
+  const surfaceOverlayOpacity = useAppearanceStore((state) => state.surfaceOverlayOpacity);
+  const setSurfaceOverlayOpacity = useAppearanceStore((state) => state.setSurfaceOverlayOpacity);
+  const overlayPercent = Math.round(surfaceOverlayOpacity * 100);
 
   const [form, setForm] = React.useState(profile);
 
@@ -61,6 +68,10 @@ export default function SettingsPage() {
     "flex w-full items-center justify-between rounded-xl border px-3 py-2 text-left text-sm transition",
     profile.notifications.push ? "border-accent/40 bg-accent/10 text-accent" : "border-inverse/10 text-muted-foreground hover:text-fg/80"
   );
+
+  const handleOverlayChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSurfaceOverlayOpacity(Number(event.target.value));
+  };
 
   return (
     <section className="space-y-6">
@@ -150,6 +161,48 @@ export default function SettingsPage() {
           <Button type="submit">Save profile</Button>
         </div>
       </form>
+
+      <section className="space-y-4 rounded-3xl border border-inverse/5 bg-card/10 p-6">
+        <header className="space-y-1">
+          <h2 className="text-lg font-semibold text-fg">Appearance</h2>
+          <p className="text-sm text-muted-foreground">
+            Adjust surface overlays to match your preferred contrast level across cards and secondary panels.
+          </p>
+        </header>
+
+        <div className="space-y-3">
+          <div className="flex items-center justify-between">
+            <Label htmlFor="surface-overlay" className="text-sm font-medium text-fg">
+              Surface overlay opacity
+            </Label>
+            <span className="text-sm font-semibold text-fg">{overlayPercent}%</span>
+          </div>
+          <input
+            id="surface-overlay"
+            type="range"
+            min={0.02}
+            max={0.6}
+            step={0.01}
+            value={surfaceOverlayOpacity}
+            onChange={handleOverlayChange}
+            aria-describedby="surface-overlay-help"
+            className="w-full accent-accent"
+          />
+          <p id="surface-overlay-help" className="text-xs text-muted-foreground">
+            Lower values keep panels transparent, higher values create denser cards. Changes apply instantly across the app.
+          </p>
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => setSurfaceOverlayOpacity(DEFAULT_SURFACE_OVERLAY_OPACITY)}
+              disabled={Math.abs(surfaceOverlayOpacity - DEFAULT_SURFACE_OVERLAY_OPACITY) < 0.001}
+            >
+              Reset to default (10%)
+            </Button>
+          </div>
+        </div>
+      </section>
 
       <div className="space-y-6 rounded-3xl border border-inverse/5 bg-card/60 p-6">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">

--- a/src/components/calendar/calendar-view.tsx
+++ b/src/components/calendar/calendar-view.tsx
@@ -447,7 +447,7 @@ export function CalendarView() {
                 {subjectFilterLabel}
               </Button>
             </PopoverTrigger>
-            <PopoverContent className="w-64 rounded-2xl border border-inverse/10 bg-card/95 p-3 text-sm text-fg">
+            <PopoverContent className="w-64 rounded-2xl p-3 text-sm text-fg">
               <div className="mb-3 flex items-center justify-between text-xs text-muted-foreground">
                 <button
                   type="button"

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -334,7 +334,7 @@ const DashboardSummaryCard = ({
   ];
 
   return (
-    <section className="dashboard-summary-card rounded-3xl border border-inverse/10 bg-card/70 bg-gradient-to-br from-bg/80 via-card/70 to-bg/80 p-6 shadow-sm transition-colors md:p-8">
+    <section className="dashboard-summary-card rounded-3xl border border-inverse/10 bg-card/10 bg-gradient-to-br from-bg/80 via-card/70 to-bg/80 p-6 shadow-sm transition-colors md:p-8">
       <div className="flex flex-col gap-8 lg:flex-row lg:justify-between">
         <div className="space-y-4 lg:max-w-xl">
           <div className="space-y-2">

--- a/src/components/dashboard/dashboard.tsx
+++ b/src/components/dashboard/dashboard.tsx
@@ -228,22 +228,15 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
 
   return (
     <section className="flex flex-col gap-10">
-      <DailySummarySection
+      <DashboardSummaryCard
         dueCount={filteredDueCount}
         upcomingCount={filteredUpcomingCount}
         streak={streak}
         nextTopic={filteredNextTopic}
+        completed={completedCount}
+        total={totalToday}
+        completionPercent={completionPercent}
       />
-
-      <div className="space-y-6">
-        <SectionDivider />
-        <ProgressTodayModule
-          completed={completedCount}
-          total={totalToday}
-          completionPercent={completionPercent}
-        />
-        <SectionDivider />
-      </div>
 
       <TopicList
         id="dashboard-topic-list"
@@ -262,90 +255,142 @@ export const Dashboard: React.FC<DashboardProps> = ({ onCreateTopic, onEditTopic
   );
 };
 
-const ProgressTodayModule = ({
-  completed,
-  total,
-  completionPercent
-}: {
-  completed: number;
-  total: number;
-  completionPercent: number;
-}) => {
-  const plannedTotal = total;
-  const displayPercent = Number.isFinite(completionPercent)
-    ? Math.max(0, Math.min(100, completionPercent))
-    : 0;
-  const isComplete = displayPercent >= 100;
-  const hasScheduledReviews = plannedTotal > 0;
-  const ratioHeading = hasScheduledReviews
-    ? `${completed}/${plannedTotal} reviews completed`
-    : `${completed} reviews completed`;
-  const summaryText = hasScheduledReviews
-    ? `You’ve completed ${completed} of ${plannedTotal} scheduled reviews for today.`
-    : "No reviews are scheduled today. Add a topic to keep the rhythm going.";
-  const encouragement = hasScheduledReviews
-    ? isComplete
-      ? "Great work! You're on track for your streak."
-      : "Keep going to finish today’s queue and boost your streak."
-    : "Plan your next review to keep the momentum strong.";
-
-  return (
-    <section className="progress-summary rounded-3xl border border-inverse/10 bg-card/60 px-6 py-8 md:px-8">
-      <div className="space-y-5">
-        <div className="space-y-2">
-          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Progress today</p>
-          <h2 className="text-2xl font-semibold text-fg">{ratioHeading}</h2>
-          <p className="text-sm text-muted-foreground">{summaryText}</p>
-        </div>
-        <div className="space-y-1">
-          <p className="text-base font-semibold text-success">{displayPercent}% complete</p>
-          <p className="text-sm font-medium text-success">{encouragement}</p>
-        </div>
-      </div>
-    </section>
-  );
-};
-
-const SectionDivider = () => <div role="separator" className="border-t border-border/60" />;
-
-const DailySummarySection = ({
+const DashboardSummaryCard = ({
   dueCount,
   upcomingCount,
   streak,
-  nextTopic
+  nextTopic,
+  completed,
+  total,
+  completionPercent
 }: {
   dueCount: number;
   upcomingCount: number;
   streak: number;
   nextTopic: Topic | null;
+  completed: number;
+  total: number;
+  completionPercent: number;
 }) => {
   const nextRelative = nextTopic ? formatRelativeToNow(nextTopic.nextReviewDate) : null;
   const nextDateLabel = nextTopic ? formatDateWithWeekday(nextTopic.nextReviewDate) : null;
   const dueLine =
     dueCount === 0
-      ? "You\u2019re all caught up. Check back tomorrow or add a topic."
+      ? "You’re all caught up. Check back tomorrow or add a topic."
       : `You have ${dueCount} topic${dueCount === 1 ? "" : "s"} ready for review. Finish them to extend your streak.`;
   const nextLine = nextTopic
-    ? `Next up: ${nextTopic.title} â€¢ ${nextRelative} (${nextDateLabel})`
+    ? `Next up: ${nextTopic.title} • ${nextRelative} (${nextDateLabel})`
     : "Next up: Add a topic to plan your next review.";
 
+  const safeCompletionPercent = Number.isFinite(completionPercent)
+    ? Math.max(0, Math.min(100, completionPercent))
+    : 0;
+  const hasPlannedReviews = total > 0;
+  const progressRatio = hasPlannedReviews ? `${completed} / ${total}` : `${completed}`;
+  const progressSummary = hasPlannedReviews
+    ? `${progressRatio} (${safeCompletionPercent}% complete)`
+    : `${progressRatio} completed`;
+  const progressMessage = hasPlannedReviews
+    ? safeCompletionPercent >= 100
+      ? "All reviews complete — stellar focus!"
+      : "Keep going to finish today’s queue!"
+    : "Plan a review to keep your streak alive.";
+
+  const metricCards: Array<{
+    label: string;
+    value: string;
+    icon: string;
+    valueClass: string;
+    iconClass: string;
+  }> = [
+    {
+      label: "Due Today",
+      value: String(dueCount),
+      icon: "📚",
+      valueClass: "status-text status-text--overdue",
+      iconClass: "status-text status-text--overdue"
+    },
+    {
+      label: "Upcoming",
+      value: String(upcomingCount),
+      icon: "⏳",
+      valueClass: "status-text status-text--upcoming",
+      iconClass: "status-text status-text--upcoming"
+    },
+    {
+      label: "Streak",
+      value: `${streak} day${streak === 1 ? "" : "s"}`,
+      icon: "🔥",
+      valueClass: "text-accent",
+      iconClass: "text-accent"
+    },
+    {
+      label: "Progress",
+      value: progressSummary,
+      icon: "📈",
+      valueClass: "text-success",
+      iconClass: "text-success"
+    }
+  ];
+
   return (
-    <section className="rounded-3xl border border-inverse/10 bg-bg/60 px-6 py-6 md:px-8">
-      <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+    <section className="dashboard-summary-card rounded-3xl border border-inverse/10 bg-card/70 bg-gradient-to-br from-bg/80 via-card/70 to-bg/80 p-6 shadow-sm transition-colors md:p-8">
+      <div className="flex flex-col gap-8 lg:flex-row lg:justify-between">
         <div className="space-y-4 lg:max-w-xl">
           <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Today\u2019s Tasks</p>
-            <p className="text-sm font-medium text-accent">Personalized review plan</p>
-            <h2 className="text-2xl font-semibold text-fg">Your next five minutes matter.</h2>
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">🗓️ Today’s Tasks</p>
+            <h2 className="text-2xl font-semibold text-fg">Personalized Review Plan</h2>
+            <p className="text-sm text-muted-foreground">
+              <span aria-hidden="true" className="mr-1">💡</span>Your next five minutes matter.
+            </p>
             <p className="text-sm text-muted-foreground">{dueLine}</p>
-            <p className="text-xs text-muted-foreground">{nextLine}</p>
+            <p className="text-xs text-muted-foreground" title={nextTopic ? nextTopic.nextReviewDate : undefined}>
+              {nextLine}
+            </p>
           </div>
         </div>
 
-        <div className="grid w-full gap-3 sm:grid-cols-3 lg:max-w-md">
-          <MetricCard label="Due today" value={dueCount} tone="status-text status-text--overdue" />
-          <MetricCard label="Upcoming" value={upcomingCount} tone="status-text status-text--upcoming" />
-          <MetricCard label="Streak" value={`${streak} day${streak === 1 ? "" : "s"}`} tone="text-fg" />
+        <div className="flex flex-col gap-4 text-right">
+          <div className="flex items-center justify-end gap-2">
+            <span className="text-3xl font-semibold text-accent">{safeCompletionPercent}%</span>
+            <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Progress</span>
+          </div>
+          <div className="flex items-center justify-end gap-2 text-sm text-muted-foreground">
+            <span aria-hidden="true">🔥</span>
+            <span className="font-medium text-fg">{streak} day{streak === 1 ? "" : "s"} streak</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {metricCards.map((metric) => (
+          <MetricCard
+            key={metric.label}
+            {...metric}
+            title={
+              metric.label === "Progress"
+                ? `Progress today: ${completed} of ${total} completed`
+                : undefined
+            }
+          />
+        ))}
+      </div>
+
+      <div
+        className="mt-8 space-y-3 rounded-2xl border border-inverse/10 bg-card/60 p-4 transition-colors hover:border-accent/40"
+        title={`Progress today: ${completed} of ${total} completed`}
+      >
+        <p className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+          <span aria-hidden="true">📈</span>
+          <span>
+            {safeCompletionPercent}% complete — {progressMessage}
+          </span>
+        </p>
+        <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-accent transition-[width] duration-500"
+            style={{ width: `${safeCompletionPercent}%` }}
+          />
         </div>
       </div>
     </section>
@@ -355,16 +400,34 @@ const DailySummarySection = ({
 const MetricCard = ({
   label,
   value,
-  tone
+  icon,
+  valueClass,
+  iconClass,
+  title
 }: {
   label: string;
-  value: number | string;
-  tone: string;
+  value: string;
+  icon: string;
+  valueClass: string;
+  iconClass: string;
+  title?: string;
 }) => (
-  <div className="rounded-2xl border border-inverse/15 bg-card/80 px-4 py-3">
-    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{label}</p>
-    <p className={cn("text-xl font-semibold", tone)}>{value}</p>
+  <div
+    className="group rounded-2xl border border-inverse/15 bg-card/60 p-4 transition-all duration-300 hover:-translate-y-0.5 hover:bg-card/80 hover:shadow-sm hover:shadow-primary/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+    tabIndex={0}
+    role="group"
+    aria-label={`${label}: ${value}`}
+    title={title}
+  >
+    <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <span
+        aria-hidden="true"
+        className={cn("text-lg transition-transform duration-300 group-hover:scale-105", iconClass)}
+      >
+        {icon}
+      </span>
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{label}</p>
+    </div>
+    <p className={cn("mt-2 text-lg font-semibold", valueClass)}>{value}</p>
   </div>
 );
-
-

--- a/src/components/dashboard/topic-list.tsx
+++ b/src/components/dashboard/topic-list.tsx
@@ -525,7 +525,7 @@ export function TopicList({
                     <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent className="w-72 rounded-2xl border border-inverse/10 bg-card/95 p-3 text-sm text-fg">
+                <PopoverContent className="w-72 rounded-2xl p-3 text-sm text-fg">
                   <div className="flex items-center justify-between gap-2">
                     <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Subjects</span>
                     <div className="flex items-center gap-2">
@@ -617,7 +617,7 @@ export function TopicList({
                     <ChevronDown className="h-3 w-3 text-muted-foreground" aria-hidden="true" /> Sort by: {sortLabels[sortOption]}
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent className="w-56 rounded-2xl border border-inverse/10 bg-card/95 p-2 text-sm text-fg">
+                <PopoverContent className="w-56 rounded-2xl p-2 text-sm text-fg">
                   <div className="space-y-1">
                     {(Object.keys(sortLabels) as SortOption[]).map((value) => (
                       <button
@@ -1066,7 +1066,7 @@ function TopicListRow({ item, subject, timezone, zonedNow, onEdit, editing }: To
                     <Ellipsis className="h-4 w-4" />
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent className="w-48 rounded-xl border border-border/60 bg-card/95 p-2 text-sm text-fg shadow-lg">
+                <PopoverContent className="w-48 rounded-xl p-2 text-sm text-fg">
                   {item.status === "due-today" ? (
                     <button
                       type="button"

--- a/src/components/layout/profile-menu.tsx
+++ b/src/components/layout/profile-menu.tsx
@@ -43,7 +43,7 @@ export const ProfileMenu: React.FC = () => {
           {avatarFallback(profile.name)}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-64 space-y-4 rounded-2xl border-inverse/10 bg-card/90 p-4 text-sm text-fg/80" sideOffset={12}>
+      <PopoverContent className="w-64 space-y-4 rounded-2xl p-4 text-sm text-fg/80" sideOffset={12}>
         <div className="flex items-center gap-3">
           <span
             className="flex h-10 w-10 items-center justify-center rounded-full text-sm font-semibold text-fg"

--- a/src/components/theme-manager.tsx
+++ b/src/components/theme-manager.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { useThemeStore } from "@/stores/theme";
+import { useAppearanceStore } from "@/stores/appearance";
 
 const THEME_STORAGE_KEY = "sr-theme";
 
@@ -13,6 +14,7 @@ export function ThemeManager() {
   const initialized = useThemeStore((state) => state.initialized);
   const setTheme = useThemeStore((state) => state.setTheme);
   const setInitialized = useThemeStore((state) => state.setInitialized);
+  const surfaceOverlayOpacity = useAppearanceStore((state) => state.surfaceOverlayOpacity);
 
   React.useEffect(() => {
     if (initialized) {
@@ -35,6 +37,16 @@ export function ThemeManager() {
     document.body.classList.add(theme);
     window.localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [initialized, theme]);
+
+  React.useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    document.documentElement.style.setProperty(
+      "--surface-overlay-alpha",
+      surfaceOverlayOpacity.toString()
+    );
+  }, [surfaceOverlayOpacity]);
 
   return null;
 }

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -15,7 +15,7 @@ const PopoverContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 w-64 rounded-xl border border-border bg-card p-3 text-sm text-fg backdrop-blur",
+      "dropdown-surface z-50 w-64 rounded-xl p-3 text-sm text-fg",
       className
     )}
     {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -37,7 +37,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-border bg-card text-fg backdrop-blur supports-[backdrop-filter]:bg-card/90",
+        "dropdown-surface z-50 min-w-[8rem] overflow-hidden rounded-xl text-fg",
         className
       )}
       position={position}
@@ -70,7 +70,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full select-none items-center rounded-md px-2 py-2 text-sm outline-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground",
+      "dropdown-item relative flex w-full select-none items-center px-3 py-2 text-sm text-fg outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-40",
       className
     )}
     {...props}
@@ -78,8 +78,8 @@ const SelectItem = React.forwardRef<
     <SelectPrimitive.ItemText asChild>
       <span className="flex flex-1 items-center gap-2">{children}</span>
     </SelectPrimitive.ItemText>
-    <SelectPrimitive.ItemIndicator className="absolute right-2 flex h-4 w-4 items-center justify-center">
-      <Check className="h-4 w-4" />
+    <SelectPrimitive.ItemIndicator className="absolute right-3 flex h-4 w-4 items-center justify-center text-accent">
+      <Check className="h-4 w-4" strokeWidth={1.5} />
     </SelectPrimitive.ItemIndicator>
   </SelectPrimitive.Item>
 ));

--- a/src/stores/appearance.ts
+++ b/src/stores/appearance.ts
@@ -1,0 +1,33 @@
+﻿"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+const MIN_OVERLAY = 0.02;
+const MAX_OVERLAY = 0.6;
+export const DEFAULT_SURFACE_OVERLAY_OPACITY = 0.1;
+
+type AppearanceState = {
+  surfaceOverlayOpacity: number;
+  setSurfaceOverlayOpacity: (value: number) => void;
+};
+
+export const clampOverlayOpacity = (value: number): number => {
+  if (Number.isNaN(value)) {
+    return DEFAULT_SURFACE_OVERLAY_OPACITY;
+  }
+  return Math.min(Math.max(value, MIN_OVERLAY), MAX_OVERLAY);
+};
+
+export const useAppearanceStore = create<AppearanceState>()(
+  persist(
+    (set) => ({
+      surfaceOverlayOpacity: DEFAULT_SURFACE_OVERLAY_OPACITY,
+      setSurfaceOverlayOpacity: (value) => set({ surfaceOverlayOpacity: clampOverlayOpacity(value) })
+    }),
+    {
+      name: "spaced-repetition-appearance",
+      version: 1
+    }
+  )
+);

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,11 +1,33 @@
+:root {
+  --surface-overlay-alpha: 0.1;
+  --dropdown-bg: #ffffff;
+  --dropdown-border: #e4e4e7;
+  --dropdown-shadow: rgba(15, 17, 21, 0.1);
+  --dropdown-hover-bg: color-mix(in srgb, var(--dropdown-bg) 90%, #21ce99 10%);
+  --accent-color: #21ce99;
+  --accent-foreground: #0f1115;
+}
+
 body.light {
   background-color: #ffffff;
   color: #1a1a1a;
+  --dropdown-bg: #ffffff;
+  --dropdown-border: #e4e4e7;
+  --dropdown-shadow: rgba(15, 17, 21, 0.12);
+  --dropdown-hover-bg: color-mix(in srgb, #ffffff 90%, #21ce99 10%);
+  --accent-color: #21ce99;
+  --accent-foreground: #0f1115;
 }
 
 body.dark {
   background-color: #0f1115;
   color: #ffffff;
+  --dropdown-bg: #18181b;
+  --dropdown-border: #27272a;
+  --dropdown-shadow: rgba(0, 0, 0, 0.24);
+  --dropdown-hover-bg: color-mix(in srgb, #18181b 90%, #3dea95 10%);
+  --accent-color: #3dea95;
+  --accent-foreground: #0f1115;
 }
 
 body.light * {
@@ -14,6 +36,32 @@ body.light * {
 
 body.dark * {
   border-color: #262a30;
+}
+
+.dropdown-surface {
+  background-color: var(--dropdown-bg);
+  border: 1px solid var(--dropdown-border);
+  box-shadow: 0 8px 20px var(--dropdown-shadow);
+  transition: background-color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.dropdown-item {
+  border-radius: 0.625rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.dropdown-item[data-highlighted],
+.dropdown-item:hover {
+  background-color: var(--dropdown-hover-bg);
+  color: var(--accent-color);
+}
+
+.dropdown-item[data-state="checked"] {
+  color: var(--accent-color);
+}
+
+[data-radix-popper-content-wrapper] > * {
+  border-radius: inherit;
 }
 
 .scrollbar-none {
@@ -91,20 +139,26 @@ body.dark .bg-bg\/95 { background-color: rgba(15, 17, 21, 0.95); }
 
 body.light .bg-card { background-color: #f8f9fa; }
 body.dark .bg-card { background-color: #181b20; }
-body.light .bg-card\/40 { background-color: rgba(248, 249, 250, 0.4); }
-body.dark .bg-card\/40 { background-color: rgba(24, 27, 32, 0.4); }
-body.light .bg-card\/50 { background-color: rgba(248, 249, 250, 0.5); }
-body.dark .bg-card\/50 { background-color: rgba(24, 27, 32, 0.5); }
-body.light .bg-card\/60 { background-color: rgba(248, 249, 250, 0.6); }
-body.dark .bg-card\/60 { background-color: rgba(24, 27, 32, 0.6); }
-body.light .bg-card\/70 { background-color: rgba(248, 249, 250, 0.7); }
-body.dark .bg-card\/70 { background-color: rgba(24, 27, 32, 0.7); }
-body.light .bg-card\/80 { background-color: rgba(248, 249, 250, 0.8); }
-body.dark .bg-card\/80 { background-color: rgba(24, 27, 32, 0.8); }
-body.light .bg-card\/90 { background-color: rgba(248, 249, 250, 0.9); }
-body.dark .bg-card\/90 { background-color: rgba(24, 27, 32, 0.9); }
-body.light .bg-card\/95 { background-color: rgba(248, 249, 250, 0.95); }
-body.dark .bg-card\/95 { background-color: rgba(24, 27, 32, 0.95); }
+body.light .bg-card\/10,
+body.light .bg-card\/40,
+body.light .bg-card\/50,
+body.light .bg-card\/60,
+body.light .bg-card\/70,
+body.light .bg-card\/80,
+body.light .bg-card\/90,
+body.light .bg-card\/95 {
+  background-color: rgb(248 249 250 / min(var(--surface-overlay-alpha), 1));
+}
+body.dark .bg-card\/10,
+body.dark .bg-card\/40,
+body.dark .bg-card\/50,
+body.dark .bg-card\/60,
+body.dark .bg-card\/70,
+body.dark .bg-card\/80,
+body.dark .bg-card\/90,
+body.dark .bg-card\/95 {
+  background-color: rgb(24 27 32 / min(var(--surface-overlay-alpha), 1));
+}
 
 body.light .bg-inverse { background-color: #e9ecf0; }
 body.dark .bg-inverse { background-color: #1f232a; }


### PR DESCRIPTION
## Summary
- merge the daily tasks and progress modules into a single dashboard summary card with motivational copy, metrics grid, and progress footer
- add interactive metric tiles with emoji icons, hover/focus feedback, and theme-aware styling
- document the unified design in DASHBOARD_UI_GUIDE.md and update the changelog entry for the redesign

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e3528502d8833180c284a0b51f5766